### PR TITLE
Avoid enabling multi-threading with only 1 thread in the thread-pool

### DIFF
--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -37,7 +37,6 @@ int main(int argc, char *argv[]) {
 
     TStopwatch timer;
     timer.Start();
-    ROOT::EnableImplicitMT(1); // for multithreading
     // ROOT logging
     auto verbosity = ROOT::Experimental::RLogScopedVerbosity(
         ROOT::Detail::RDF::RDFLogChannel(),


### PR DESCRIPTION
EnableImplicitMT(1) does not start a single-thread analysis, it
starts a multi-thread analysis on only one thread (which might incur
in some overhead without any gain in parallelism).