### PR TITLE
Avoid enabling multi-threading with only 1 thread in the thread-pool

### DIFF
--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -37,7 +37,6 @@ int main(int argc, char *argv[]) {
 
     TStopwatch timer;
     timer.Start();
-    ROOT::EnableImplicitMT(1); // for multithreading
     // ROOT logging
     auto verbosity = ROOT::Experimental::RLogScopedVerbosity(
         ROOT::Detail::RDF::RDFLogChannel(),

--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -45,7 +45,6 @@ int main(int argc, char *argv[]) {
 
     // file logging
     ROOT::RDataFrame df0("Events", input_path);
-    // for testing, we limit to 1000 events only
     // 1st stage: Good object selection
     Logger::enableFileLogging("logs/main.txt");
     Logger::setLevel(Logger::LogLevel::INFO);

--- a/src/utility/RooFunctorThreadsafe.hxx
+++ b/src/utility/RooFunctorThreadsafe.hxx
@@ -20,7 +20,9 @@ class RooFunctorThreadsafe {
     // necessary.
 
   public:
-    RooFunctorThreadsafe(RooAbsReal const &function, RooArgSet const &args) {
+    RooFunctorThreadsafe(RooAbsReal const &function, RooArgSet const &args,
+                         RooWorkspace *ws)
+        : workspace_(ws) {
         executors_.emplace_back(function, args);
         // to avoid reallocation for executor vector which is not threadsafe
         executors_.reserve(maxNExecutors);
@@ -95,6 +97,10 @@ class RooFunctorThreadsafe {
 
     mutable std::mutex mutex_;
     std::vector<Executor> executors_;
+    // some of the objects indirectly used by the executors, such as RooDataHists, might be
+    // owned by the RooWorkspace where they came from, so we tie the workspace's lifetime
+    // to the one of the RooFunctorThreadsafe object
+    std::unique_ptr<RooWorkspace> workspace_;
 
     constexpr static int maxNExecutors = 100;
 };
@@ -128,10 +134,7 @@ inline auto loadFunctor(const std::string &workspace_name,
     auto func = workspace->function(functor_name.c_str());
     auto args = workspace->argSet(arguments.c_str());
 
-    auto functor = std::make_shared<RooFunctorThreadsafe>(*func, args);
-
-    // we can delete the workspace since we copied the functions out of it
-    delete workspace;
+    auto functor = std::make_shared<RooFunctorThreadsafe>(*func, args, workspace);
     return functor;
 }
 

--- a/src/utility/RooFunctorThreadsafe.hxx
+++ b/src/utility/RooFunctorThreadsafe.hxx
@@ -121,8 +121,9 @@ inline auto loadFunctor(const std::string &workspace_name,
                  const std::string &functor_name,
                  const std::string &arguments) {
     // first load the workspace
-    auto workspacefile = TFile::Open(workspace_name.c_str(), "read");
-    auto workspace = (RooWorkspace *)workspacefile->Get("w");
+    std::unique_ptr<TFile> workspacefile{
+        TFile::Open(workspace_name.c_str(), "read")};
+    auto workspace = workspacefile->Get<RooWorkspace>("w");
     workspacefile->Close();
     auto func = workspace->function(functor_name.c_str());
     auto args = workspace->argSet(arguments.c_str());

--- a/src/utility/RooFunctorThreadsafe.hxx
+++ b/src/utility/RooFunctorThreadsafe.hxx
@@ -117,7 +117,7 @@ class RooFunctorThreadsafe {
  * functor used for evaluation
  */
 
-auto loadFunctor(const std::string &workspace_name,
+inline auto loadFunctor(const std::string &workspace_name,
                  const std::string &functor_name,
                  const std::string &arguments) {
     // first load the workspace

--- a/src/utility/RooFunctorThreadsafe.hxx
+++ b/src/utility/RooFunctorThreadsafe.hxx
@@ -97,9 +97,10 @@ class RooFunctorThreadsafe {
 
     mutable std::mutex mutex_;
     std::vector<Executor> executors_;
-    // some of the objects indirectly used by the executors, such as RooDataHists, might be
-    // owned by the RooWorkspace where they came from, so we tie the workspace's lifetime
-    // to the one of the RooFunctorThreadsafe object
+    // some of the objects indirectly used by the executors, such as
+    // RooDataHists, might be owned by the RooWorkspace where they came from, so
+    // we tie the workspace's lifetime to the one of the RooFunctorThreadsafe
+    // object
     std::unique_ptr<RooWorkspace> workspace_;
 
     constexpr static int maxNExecutors = 100;
@@ -124,8 +125,8 @@ class RooFunctorThreadsafe {
  */
 
 inline auto loadFunctor(const std::string &workspace_name,
-                 const std::string &functor_name,
-                 const std::string &arguments) {
+                        const std::string &functor_name,
+                        const std::string &arguments) {
     // first load the workspace
     std::unique_ptr<TFile> workspacefile{
         TFile::Open(workspace_name.c_str(), "read")};
@@ -134,7 +135,8 @@ inline auto loadFunctor(const std::string &workspace_name,
     auto func = workspace->function(functor_name.c_str());
     auto args = workspace->argSet(arguments.c_str());
 
-    auto functor = std::make_shared<RooFunctorThreadsafe>(*func, args, workspace);
+    auto functor =
+        std::make_shared<RooFunctorThreadsafe>(*func, args, workspace);
     return functor;
 }
 


### PR DESCRIPTION
EnableImplicitMT(1) does not start a single-thread analysis, it
starts a multi-thread analysis on only one thread (which might incur
in some overhead without any gain in parallelism).