### PR TITLE
add option to add subproducers scope dependent

### DIFF
--- a/code_generation/producers/scalefactors.py
+++ b/code_generation/producers/scalefactors.py
@@ -6,28 +6,54 @@ from code_generation.producer import Producer, ProducerGroup
 # The readout is done via RooWorkspaces
 ############################
 
-MuonID_SF = Producer(
+Muon_1_ID_SF = Producer(
     name="MuonID_SF",
     call='scalefactor::muon::id({df}, {input}, {output}, "{muon_sf_workspace}", "{muon_sf_id_name}", "{muon_sf_id_args}")',
     input=[q.pt_1, q.eta_1],
     output=[q.idWeight_1],
-    scopes=["mt"],
+    scopes=["mt", "mm"],
 )
-MuonIso_SF = Producer(
+Muon_1_Iso_SF = Producer(
     name="MuonIso_SF",
     call='scalefactor::muon::iso({df}, {input}, {output}, "{muon_sf_workspace}", "{muon_sf_iso_name}", "{muon_sf_iso_args}")',
     input=[q.pt_1, q.eta_1, q.iso_1],
     output=[q.isoWeight_1],
-    scopes=["mt"],
+    scopes=["mt", "mm"],
+)
+Muon_2_ID_SF = Producer(
+    name="MuonID_SF",
+    call='scalefactor::muon::id({df}, {input}, {output}, "{muon_sf_workspace}", "{muon_sf_id_name}", "{muon_sf_id_args}")',
+    input=[q.pt_2, q.eta_2],
+    output=[q.idWeight_2],
+    scopes=["em", "mm"],
+)
+Muon_2_Iso_SF = Producer(
+    name="MuonIso_SF",
+    call='scalefactor::muon::iso({df}, {input}, {output}, "{muon_sf_workspace}", "{muon_sf_iso_name}", "{muon_sf_iso_args}")',
+    input=[q.pt_2, q.eta_2, q.iso_2],
+    output=[q.isoWeight_2],
+    scopes=["em", "mm"],
 )
 MuonIDIso_SF = ProducerGroup(
     name="MuonIDIso_SF",
     call=None,
     input=None,
     output=None,
-    scopes=["mt"],
-    subproducers=[
-        MuonID_SF,
-        MuonIso_SF,
-    ],
+    scopes=["mt", "em", "mm"],
+    subproducers={
+        "mt": [
+            Muon_1_ID_SF,
+            Muon_1_Iso_SF,
+        ],
+        "em": [
+            Muon_2_ID_SF,
+            Muon_2_Iso_SF,
+        ],
+        "mm": [
+            Muon_1_ID_SF,
+            Muon_1_Iso_SF,
+            Muon_2_ID_SF,
+            Muon_2_Iso_SF,
+        ],
+    },
 )


### PR DESCRIPTION
This PR adds the option to assign different subproducers to a ProducerGroup, depending on the scope. One example is the configuration of the MuonSF Producer Group, where different producers are needed, depending on the scope:

```py
MuonIDIso_SF = ProducerGroup(
    name="MuonIDIso_SF",
    call=None,
    input=None,
    output=None,
    scopes=["mt", "em", "mm"],
    subproducers={
        "mt": [
            Muon_1_ID_SF,
            Muon_1_Iso_SF,
        ],
        "em": [
            Muon_2_ID_SF,
            Muon_2_Iso_SF,
        ],
        "mm": [
            Muon_1_ID_SF,
            Muon_1_Iso_SF,
            Muon_2_ID_SF,
            Muon_2_Iso_SF,
        ],
    },
)
```