### PR TITLE
Add support for multiple input files

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Install missing software
-        run: pacman -Syu --noconfirm git cmake make doxygen python-pip && pip install breathe==4.29 sphinx_rtd_theme==0.5
+        run: pacman -Syu --noconfirm git cmake make doxygen python-pip && pip install breathe==4.31 sphinx_rtd_theme==0.5
 
       - uses: actions/checkout@v2
 

--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -37,8 +37,11 @@ int main(int argc, char *argv[]) {
         gErrorIgnoreLevel = 6001; // ignore all ROOT errors
     }
     if (argc < 3) {
-        Logger::get("main")->critical("Require at least two arguments: N input "
-                                      "files and a single output file");
+        Logger::get("main")->critical(
+            "Require at least two arguments: a single output file and N input "
+            "files \n"
+            "Example:\n"
+            "./analysis output.root /path/to/inputfiles/*.root");
         return 1;
     }
     if (argc > 3) {

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -30,7 +30,7 @@ function(find_python_package PYPINAME NAME MIN_VERSION)
     message(STATUS "Found Python package ${PYPINAME} (require ${MIN_VERSION}, found ${PACKAGE_VERSION})")
 endfunction()
 
-find_python_package(breathe breathe 4.29)
+find_python_package(breathe breathe 4.31)
 find_python_package(sphinx_rtd_theme sphinx_rtd_theme 0.5)
 
 # adapted from https://devblogs.microsoft.com/cppblog/clear-functional-c-documentation-with-sphinx-breathe-doxygen-cmake/

--- a/src/defaults.hxx
+++ b/src/defaults.hxx
@@ -1,6 +1,8 @@
 #ifndef GUARDDEFAULTS_H
 #define GUARDDEFAULTS_H
 
+#include <Math/Vector4D.h>
+
 int default_int = -10;
 int default_pdgid = -999;
 float default_float = -10.0;


### PR DESCRIPTION
This PR adds support for N input files. This changes the way, CROWN arguments have to be provided, now the output file is the FIRST argument, followed by N output files


Example command
```bash
./analysis output.root /path/to/inputfiles/*.root
```

Also added a verbose variable to hide some more debug-like output
