### PR TITLE
add multithread option and process printing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,12 @@ if (NOT DEFINED ERAS)
     message(FATAL_ERROR "Please specify the eras to be used with -DERAS=eras")
 endif()
 
-message(STATUS "Set up analysis with --config ${ANALYSIS} --channels ${CHANNELS} --shifts ${SHIFTS} --samples ${SAMPLES} --eras ${ERAS} --debug ${DEBUG}")
+if (NOT DEFINED THREADS)
+    message(STATUS "No threads set, using single threaded mode with -DTHREADS=1")
+    set(THREADS "1")
+endif()
+
+message(STATUS "Set up analysis with --config ${ANALYSIS} --channels ${CHANNELS} --shifts ${SHIFTS} --samples ${SAMPLES} --eras ${ERAS} --debug ${DEBUG} --threads ${THREADS}")
 
 # Define the default compiler flags for different build types, if different from the cmake defaults
 set(CMAKE_CXX_FLAGS_DEBUG "-g" CACHE STRING "Set default compiler flags for build type Debug")
@@ -172,7 +177,7 @@ message(STATUS "")
 
 file(MAKE_DIRECTORY ${GENERATE_CPP_OUTPUT_DIRECTORY})
 execute_process(
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/generate.py --template ${GENERATE_CPP_INPUT_TEMPLATE} --output ${GENERATE_CPP_OUTPUT_DIRECTORY} --analysis ${ANALYSIS} --channels ${CHANNELS} --shifts ${SHIFTS} --samples ${SAMPLES} --eras ${ERAS} --debug ${DEBUG} RESULT_VARIABLE ret)
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/generate.py --template ${GENERATE_CPP_INPUT_TEMPLATE} --output ${GENERATE_CPP_OUTPUT_DIRECTORY} --analysis ${ANALYSIS} --channels ${CHANNELS} --shifts ${SHIFTS} --samples ${SAMPLES} --eras ${ERAS} --threads ${THREADS} --debug ${DEBUG} RESULT_VARIABLE ret)
 if(ret EQUAL "1")
     message( FATAL_ERROR "Code Generation Failed - Exiting !")
 endif()

--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -56,16 +56,18 @@ int main(int argc, char *argv[]) {
     Logger::get("main")->info("Output directory: {}", output_path);
     TStopwatch timer;
     timer.Start();
+    int quantile = 10000;
 
     // file logging
     Logger::enableFileLogging("logs/main.txt");
-    // initialize df
-    ROOT::RDataFrame df0("Events", input_files);
-    Logger::get("main")->info("Starting Setup of Dataframe");
 
     // set mutlithreading if  is enabled using ROOT::EnableImplicitMT(ncores)
 
     // {MULTITHREADING}
+
+    // initialize df
+    ROOT::RDataFrame df0("Events", input_files);
+    Logger::get("main")->info("Starting Setup of Dataframe");
 
     // auto df_final = df0;
 
@@ -82,6 +84,7 @@ int main(int argc, char *argv[]) {
     Logger::get("main")->info("Starting Evaluation");
     ROOT::RDF::RSnapshotOptions dfconfig;
     dfconfig.fLazy = true;
+
     // {RUN_COMMANDS}
     // Add meta-data
     // clang-format off

--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -63,6 +63,10 @@ int main(int argc, char *argv[]) {
     ROOT::RDataFrame df0("Events", input_files);
     Logger::get("main")->info("Starting Setup of Dataframe");
 
+    // set mutlithreading if  is enabled using ROOT::EnableImplicitMT(ncores)
+
+    // {MULTITHREADING}
+
     // auto df_final = df0;
 
     // {CODE_GENERATION}

--- a/code_generation/code_generation.py
+++ b/code_generation/code_generation.py
@@ -145,3 +145,42 @@ def fill_template(t: str, config: Dict[Any, Any]) -> str:
         .replace("{COMMITHASH}", '"%s"' % current_commit)
         .replace("{CLEANSETUP}", setup_is_clean)
     )
+
+
+def set_tags(template: str, analysisname: str, era: str, sample_group: str) -> str:
+    """
+    Function used to set the tags in the template.
+
+    Args:
+        template: The template to be modified.
+        analysisname: The name of the analysis.
+        era: The era of the analysis.
+        sample_group: The sample group of the analysis.
+
+    Returns:
+        The modified template.
+    """
+    return (
+        template.replace("{ANALYSISTAG}", '"Analysis=%s"' % analysisname)
+        .replace("{ERATAG}", '"Era=%s"' % era)
+        .replace("{SAMPLETAG}", '"Samplegroup=%s"' % sample_group)
+    )
+
+
+def set_thead_flag(template: str, threads: int) -> str:
+    """
+    Set the multithreading flag in the template if the number of threads is greater than 1.
+
+    Args:
+        template: The template to be modified.
+        threads: The number of threads to be used.
+
+    Returns:
+        The modified template.
+    """
+    if threads > 1:
+        return template.replace(
+            "// {MULTITHREADING}", "ROOT::EnableImplicitMT({});".format(threads)
+        )
+    else:
+        return template.replace("// {MULTITHREADING}", "")

--- a/code_generation/producers/genparticles.py
+++ b/code_generation/producers/genparticles.py
@@ -216,7 +216,7 @@ UnrollGenMuLV1 = ProducerGroup(
     input=None,
     output=None,
     scopes=["mt", "mm"],
-    subproducers=[gen_pt_1, gen_eta_1, gen_phi_1, gen_mass_1],
+    subproducers=[gen_pt_1, gen_eta_1, gen_phi_1, gen_mass_1, gen_pdgid_1],
 )
 UnrollGenMuLV2 = ProducerGroup(
     name="UnrollGenMuLV2",
@@ -224,7 +224,7 @@ UnrollGenMuLV2 = ProducerGroup(
     input=None,
     output=None,
     scopes=["em", "mm"],
-    subproducers=[gen_pt_2, gen_eta_2, gen_phi_2, gen_mass_2],
+    subproducers=[gen_pt_2, gen_eta_2, gen_phi_2, gen_mass_2, gen_pdgid_2],
 )
 UnrollGenElLV1 = ProducerGroup(
     name="UnrollGenElLV1",

--- a/generate.py
+++ b/generate.py
@@ -5,7 +5,12 @@ import importlib
 import logging
 import logging.handlers
 import sys
-from code_generation.code_generation import fill_template, set_tags, set_thead_flag
+from code_generation.code_generation import (
+    fill_template,
+    set_tags,
+    set_thead_flag,
+    set_process_tracking,
+)
 
 sys.dont_write_bytecode = True
 
@@ -105,6 +110,8 @@ for era in args.eras:
         template = set_tags(template, analysisname, era, sample_group)
         # if the number of threads is greater than one, add the threading flag in the code
         template = set_thead_flag(template, args.threads)
+        # generate the code for the process tracking in the df
+        template = set_process_tracking(template, args.channels)
         with open(path.join(args.output, executable), "w") as executable_file:
             executable_file.write(template)
         executables.append(executable)


### PR DESCRIPTION
This PR adds two small convenience features to CROWN:

1. easy multithreading option: The multithreading can now be set via the cmake build command using `DTHREADS = NumberOfThreads`. The default value is still 1, but especially for local testing, the value can be increased here
2. A tracking of the status while executing CROWN, especially for longer tasks this makes it easier so see how the progress of the processing is doing. It will produce an output that looks like this:

```
[2022-01-11 13:45:17.878] [main] [info] Starting Evaluation
[2022-01-11 13:45:22.273] [main - mt Channel] [info] 10000 Events processed ...
[2022-01-11 13:45:22.634] [main - mt Channel] [info] 20000 Events processed ...
[2022-01-11 13:45:23.030] [main - mt Channel] [info] 30000 Events processed ...
[2022-01-11 13:45:23.419] [main - mt Channel] [info] 40000 Events processed ...
[2022-01-11 13:45:23.709] [main - mt Channel] [info] 50000 Events processed ...
[2022-01-11 13:45:24.016] [main - mt Channel] [info] 60000 Events processed ...
[2022-01-11 13:45:24.394] [main - mt Channel] [info] 70000 Events processed ...
[2022-01-11 13:45:24.747] [main - mt Channel] [info] 80000 Events processed ...
[2022-01-11 13:45:25.079] [main - mt Channel] [info] 90000 Events processed ...
[2022-01-11 13:45:25.523] [main - mt Channel] [info] 100000 Events processed ...
[2022-01-11 13:45:25.546] [main] [info] mt:
GoldenJSONFilter: pass=89706      all=100000     -- eff=89.71 % cumulative eff=89.71 %
Flag_goodVertices: pass=89706      all=89706      -- eff=100.00 % cumulative eff=89.71 %
Flag_METFilters: pass=89684      all=89706      -- eff=99.98 % cumulative eff=89.68 %
GoodMuTauPairs: pass=8412       all=89684      -- eff=9.38 % cumulative eff=8.41 %
[2022-01-11 13:45:25.550] [main] [info] Finished Evaluation
[2022-01-11 13:45:25.550] [main] [info] Overall runtime (real time: 8.443236112594604, CPU time: 8.18)

```