### PR TITLE
add functionality to the shifts option

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ env:
   SAMPLES: dy
   ERAS: 2018
   CHANNELS: "mt,mm"
-  SHIFTS: "tauES"
+  SHIFTS: "tauES,metUnclusteredEnUp"
 
 jobs:
   build_project:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,8 @@ env:
   ANALYSIS: test.unittest_config
   SAMPLES: dy
   ERAS: 2018
-  CHANNELS: "mt;mm"
+  CHANNELS: "mt,mm"
+  SHIFTS: "tauES"
 
 jobs:
   build_project:
@@ -38,7 +39,7 @@ jobs:
 
       - name: Configure CMake
         shell: bash
-        run: cd ${{github.workspace}}/build && cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DANALYSIS=$ANALYSIS -DSAMPLES=$SAMPLES -DERAS=$ERAS -DCHANNELS=$CHANNELS
+        run: cd ${{github.workspace}}/build && cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DANALYSIS=$ANALYSIS -DSAMPLES=$SAMPLES -DERAS=$ERAS -DCHANNELS=$CHANNELS -DSHIFTS=$SHIFTS
 
       - name: Build
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if (NOT DEFINED CHANNELS)
 endif()
 
 if (NOT DEFINED SHIFTS)
-    message(STATUS "No shifts specificed, using -DSHIFTS=all. If you want to run nominal only, use -DSHIFTS=nominal")
+    message(STATUS "No shifts specificed, using -DSHIFTS=all. If you want to run nominal only, use -DSHIFTS=none")
     set(SHIFTS "all")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,12 @@ endif()
 message(STATUS "Set up analysis for config ${ANALYSIS}.")
 
 if (NOT DEFINED CHANNELS)
-    message(STATUS "No channel specificed, build the four main channels using -DCHANNELS=et;mt;tt;em")
-    set(CHANNELS "et;mt;tt;em")
+    message(STATUS "No channel specificed, build the four main channels using -DCHANNELS=et,mt,tt,em")
+    set(CHANNELS "et,mt,tt,em")
 endif()
 
 if (NOT DEFINED SHIFTS)
-    message(STATUS "No shifts specificed, using -DSHIFTS=all")
+    message(STATUS "No shifts specificed, using -DSHIFTS=all. If you want to run nominal only, use -DSHIFTS=nominal")
     set(SHIFTS "all")
 endif()
 
@@ -35,7 +35,9 @@ if (NOT DEFINED THREADS)
     set(THREADS "1")
 endif()
 
-message(STATUS "Set up analysis with --config ${ANALYSIS} --channels ${CHANNELS} --shifts ${SHIFTS} --samples ${SAMPLES} --eras ${ERAS} --debug ${DEBUG} --threads ${THREADS}")
+string (REPLACE "," ";" ERAS "${ERAS}")
+string (REPLACE "," ";" SAMPLES "${SAMPLES}")
+message(STATUS "Set up analysis with --config ${ANALYSIS} --channels ${CHANNELS} --shifts ${SHIFTS} --samples ${SAMPLES} --eras ${ERAS} --threads ${THREADS} --debug ${DEBUG}")
 
 # Define the default compiler flags for different build types, if different from the cmake defaults
 set(CMAKE_CXX_FLAGS_DEBUG "-g" CACHE STRING "Set default compiler flags for build type Debug")
@@ -175,11 +177,18 @@ message(STATUS "  Eras: ${ERAS}")
 message(STATUS "")
 
 file(MAKE_DIRECTORY ${GENERATE_CPP_OUTPUT_DIRECTORY})
-execute_process(
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/generate.py --template ${GENERATE_CPP_INPUT_TEMPLATE} --output ${GENERATE_CPP_OUTPUT_DIRECTORY} --analysis ${ANALYSIS} --channels ${CHANNELS} --shifts ${SHIFTS} --samples ${SAMPLES} --eras ${ERAS} --threads ${THREADS} --debug ${DEBUG} RESULT_VARIABLE ret)
-if(ret EQUAL "1")
-    message( FATAL_ERROR "Code Generation Failed - Exiting !")
-endif()
+# loop over all samples and eras and generate code for each one of them
+foreach (ERA IN LISTS ERAS)
+    foreach (SAMPLE IN LISTS SAMPLES)
+        execute_process(
+            COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/generate.py --template ${GENERATE_CPP_INPUT_TEMPLATE} --output ${GENERATE_CPP_OUTPUT_DIRECTORY} --analysis ${ANALYSIS} --channels ${CHANNELS} --shifts ${SHIFTS} --sample ${SAMPLE} --era ${ERA} --threads ${THREADS} --debug ${DEBUG} RESULT_VARIABLE ret)
+        if(ret EQUAL "1")
+            message( FATAL_ERROR "Code Generation Failed - Exiting !")
+        endif()
+    endforeach()
+endforeach()
+
+
 set(GENERATE_CPP_OUTPUT_FILELIST "${GENERATE_CPP_OUTPUT_DIRECTORY}/files.txt")
 if(NOT EXISTS ${GENERATE_CPP_OUTPUT_FILELIST})
     message(FATAL_ERROR "List of generated C++ files in ${GENERATE_CPP_OUTPUT_FILELIST} does not exist.")

--- a/code_generation/code_generation.py
+++ b/code_generation/code_generation.py
@@ -95,8 +95,8 @@ def fill_template(t: str, config: Dict[Any, Any]) -> str:
         runcommands += '    auto {scope}_result = {scope}_df_final.Snapshot("ntuple", {outputname}, {outputstring}, dfconfig);\n'.format(
             scope=scope, outputname=outputname, outputstring=outputstring
         )
+    runcommands += "{PROGRESS_CALLBACK}\n"
     for scope in config["output"]:
-        runcommands += "{PROGRESS_CALLBACK}\n"
         runcommands += "    %s_result.GetValue();\n" % scope
         runcommands += '    Logger::get("main")->info("%s:");\n' % scope
         runcommands += "    %s_cutReport->Print();\n" % scope

--- a/code_generation/configuration.py
+++ b/code_generation/configuration.py
@@ -499,18 +499,24 @@ class Configuration(object):
             for scope in self.scopes:
                 self.shifts[scope] = {}
         else:
+            # check if all selected shifts are available
             for scope in self.available_shifts:
-                for shift in self.selected_shifts:
-                    if len(self.available_shifts[scope]) == 0:
-                        raise InvalidShiftError(shift, self.sample)
-                    log.debug("Validating shift {} in scope {}".format(shift, scope))
-                    if not any(
-                        [
-                            shift in available_shift
-                            for available_shift in self.available_shifts[scope]
-                        ]
-                    ):
-                        raise InvalidShiftError(shift, self.sample, scope)
+                # we do not need to check the global scope, since shifts from
+                # the global scope are always propagated down to all scopes
+                if scope is not self.global_scope:
+                    for shift in self.selected_shifts:
+                        if len(self.available_shifts[scope]) == 0:
+                            raise InvalidShiftError(shift, self.sample)
+                        log.debug(
+                            "Validating shift {} in scope {}".format(shift, scope)
+                        )
+                        if not any(
+                            [
+                                shift in available_shift
+                                for available_shift in self.available_shifts[scope]
+                            ]
+                        ):
+                            raise InvalidShiftError(shift, self.sample, scope)
         log.info("Shift configuration is valid")
 
     def validate(self) -> None:

--- a/code_generation/configuration.py
+++ b/code_generation/configuration.py
@@ -24,12 +24,6 @@ from code_generation.systematics import SystematicShift, SystematicShiftByQuanti
 
 log = logging.getLogger(__name__)
 # type aliases
-ScopeSet = Set[str]
-ScopeList = Union[str, List[str]]
-EraList = Union[str, List[str]]
-ChannelList = Union[str, List[str]]
-ShiftList = Set[str]
-SamplesList = Union[str, List[str]]
 TConfiguration = Dict[
     str,
     Union[
@@ -268,39 +262,39 @@ class Configuration(object):
         Returns:
             None
         """
-        if self.valid_shift(shift):
+        if self._is_valid_shift(shift):
             log.debug("Shift {} is valid".format(shift.shiftname))
             if not isinstance(shift, SystematicShift):
                 raise TypeError("shift must be of type SystematicShift")
             if isinstance(samples, str):
                 samples = [samples]
             if samples is None or self.sample in samples:
-                scopes_to_shift: ScopeList = [
+                scopes_to_shift = [
                     scope for scope in shift.get_scopes() if scope in self.scopes
                 ]
                 if self.global_scope in scopes_to_shift:
                     for scope in self.scopes:
                         if scope in shift.get_scopes():
-                            self.add_available_shift(shift, scope)
+                            self._add_available_shift(shift, scope)
                             shift.apply(scope)
                             self.shifts[scope][
                                 shift.shiftname
                             ] = shift.get_shift_config(scope)
                         else:
-                            self.add_available_shift(shift, scope)
+                            self._add_available_shift(shift, scope)
                             shift.apply(self.global_scope)
                             self.shifts[scope][
                                 shift.shiftname
                             ] = shift.get_shift_config(self.global_scope)
                 else:
                     for scope in scopes_to_shift:
-                        self.add_available_shift(shift, scope)
+                        self._add_available_shift(shift, scope)
                         shift.apply(scope)
                         self.shifts[scope][shift.shiftname] = shift.get_shift_config(
                             scope
                         )
 
-    def valid_shift(
+    def _is_valid_shift(
         self, shift: Union[SystematicShift, SystematicShiftByQuantity]
     ) -> bool:
         """
@@ -326,7 +320,7 @@ class Configuration(object):
                 ]
             )
 
-    def add_available_shift(
+    def _add_available_shift(
         self, shift: Union[SystematicShift, SystematicShiftByQuantity], scope
     ) -> None:
         """Add a shift to the set of available shifts
@@ -485,7 +479,7 @@ class Configuration(object):
             if len(missing_outputs) > 0:
                 raise InvalidOutputError(scope, missing_outputs)
 
-    def validate_all_shifts(self) -> None:
+    def _validate_all_shifts(self) -> None:
         """
         Function to validate the set of selected shifts against the set of available shifts.
         If a shift is required, that is not set, an error is raised.
@@ -533,7 +527,7 @@ class Configuration(object):
             None
         """
         self._validate_outputs()
-        self.validate_all_shifts()
+        self._validate_all_shifts()
 
     def report(self) -> None:
         """

--- a/code_generation/exceptions.py
+++ b/code_generation/exceptions.py
@@ -73,3 +73,20 @@ class InvalidProducerConfigurationError(ConfigurationError):
             producer,
         )
         super().__init__(self.message)
+
+
+class InvalidShiftError(ConfigurationError):
+    """
+    Exception raised when the shift configuration provided by the user is not valid.
+    """
+
+    def __init__(self, shift: str, sample: str, scope: Union[str, None] = None):
+        if scope is None:
+            self.message = "Shift {} is not setup properly or not available for sampletype {}".format(
+                shift, sample
+            )
+        else:
+            self.message = "Shift {} is not setup for scope {} or not available for sampletype {}".format(
+                shift, scope, sample
+            )
+        super().__init__(self.message)

--- a/config/config.py
+++ b/config/config.py
@@ -41,6 +41,7 @@ def build_config(
         available_eras,
         available_channels,
     )
+
     # first add default parameters necessary for all scopes
     configuration.add_config_parameters(
         "global",
@@ -298,6 +299,7 @@ def build_config(
             muons.VetoMuons,
             muons.VetoSecondMuon,
             muons.ExtraMuonsVeto,
+            muons.NumberOfGoodMuons,
             pairselection.ZMMPairSelection,
             pairselection.GoodMMPairFilter,
             pairselection.LVMu1,
@@ -435,7 +437,6 @@ def build_config(
             q.mjj,
             q.m_vis,
             q.pt_vis,
-            q.ntaus,
             q.nmuons,
             q.nbtag,
             q.bpt_1,
@@ -494,6 +495,7 @@ def build_config(
     configuration.add_outputs(
         "mt",
         [
+            q.ntaus,
             triggers.MTGenerateSingleMuonTriggerFlags.output_group,
             triggers.MTGenerateCrossTriggerFlags.output_group,
             q.taujet_pt_2,

--- a/config/test/unittest_config.py
+++ b/config/test/unittest_config.py
@@ -432,6 +432,25 @@ def build_config(
         ],
     )
     #########################
+    # TES Shifts
+    #########################
+    configuration.add_shift(
+        SystematicShift(
+            name="tauES_1prong0pizeroDown",
+            shift_config={"global": {"tau_ES_shift_DM0": 0.998}},
+            producers={"global": taus.TauPtCorrection},
+            ignore_producers={"mt": [pairselection.LVMu1, muons.VetoMuons]},
+        )
+    )
+    configuration.add_shift(
+        SystematicShift(
+            name="tauES_1prong0pizeroUp",
+            shift_config={"global": {"tau_ES_shift_DM0": 1.002}},
+            producers={"global": taus.TauPtCorrection},
+            ignore_producers={"mt": [pairselection.LVMu1, muons.VetoMuons]},
+        )
+    )
+    #########################
     # MET Shifts
     #########################
     configuration.add_shift(


### PR DESCRIPTION
Resolves #122 

The PR adds functionality to the `-DSHIFTS` option, which was only a dummy before. Now, the user can use this option to run only on a subset of systematic shifts or even no shift:
1.  `-DSHIFTS=none` runs nominal only, without any shifts
2.  `-DSHIFTS=all` runs all shifts only, this is the default if no option is provided
3.  `-DSHIFTS=comma,seperated,list,of,shifts` runs all shifts that match any of the strings in the list. So `-DSHIFTS=tauES` would match all shifts containing `tauES` in the name, including both the up and down variant. 

Additionally, some cleanup of the `generate.py`script was done, an the looping over multiple eras or samples during the code generation was moved to the cmake file, eliminating the python for loop in `generate.py`

As soon as #120 is merged, this update to the cmake command should also be documented there