### PR TITLE
update trigger function to use regex matching and not crash, if a trigger is not found

### DIFF
--- a/src/triggers.cxx
+++ b/src/triggers.cxx
@@ -260,9 +260,9 @@ ROOT::RDF::RNode GenerateSingleTriggerFlag(
     // if no matching trigger was found return the initial dataframe
     if (matched_trigger_names.size() == 0) {
         Logger::get("GenerateSingleTriggerFlag")
-            ->info(
-                "No matching trigger for {} found, returning 0 as trigger flag",
-                hltpath);
+            ->info("No matching trigger for {} found, returning false for "
+                   "trigger flag {}",
+                   hltpath, triggerflag_name);
         auto df1 = df.Define(triggerflag_name, []() { return false; });
         return df1;
     } else if (matched_trigger_names.size() > 1) {
@@ -394,26 +394,26 @@ ROOT::RDF::RNode GenerateDoubleTriggerFlag(
     // matching any of them
     for (auto &trigger : available_trigger) {
         if (std::regex_match(trigger, hltpath_regex)) {
-            Logger::get("GenerateSingleTriggerFlag")
+            Logger::get("GenerateDoubleTriggerFlag")
                 ->debug("Found matching trigger: {}", trigger);
             matched_trigger_names.push_back(trigger);
         }
     }
     // if no matching trigger was found return the initial dataframe
     if (matched_trigger_names.size() == 0) {
-        Logger::get("GenerateSingleTriggerFlag")
-            ->info(
-                "No matching trigger for {} found, returning 0 as trigger flag",
-                hltpath);
+        Logger::get("GenerateDoubleTriggerFlag")
+            ->info("No matching trigger for {} found, returning false for "
+                   "trigger flag {}",
+                   hltpath, triggerflag_name);
         auto df1 = df.Define(triggerflag_name, []() { return false; });
         return df1;
     } else if (matched_trigger_names.size() > 1) {
-        Logger::get("GenerateSingleTriggerFlag")
+        Logger::get("GenerateDoubleTriggerFlag")
             ->warn("More than one matching trigger found, not implemented yet");
         throw std::invalid_argument(
             "received too many matching trigger paths, not implemented yet");
     } else {
-        Logger::get("GenerateSingleTriggerFlag")
+        Logger::get("GenerateDoubleTriggerFlag")
             ->debug("Found matching trigger: {}", matched_trigger_names[0]);
         auto df1 =
             df.Define(triggerflag_name, triggermatch,


### PR DESCRIPTION
In the current version of the trigger producer, the executable crashes, if a trigger path is not found in the input file. In data, it can happen, that a trigger path is only available in a fraction of all events (e.g. the `hps` triggers in 2018). 
With this PR, the trigger producer checks a given hltpath against all available hltpaths. 

	If no match is found, false is returned for all events
	If one match is found, the behavior is identical to before
	if more the one match is found and exception is thrown for now (to be implemented in the future)