### PR TITLE
PU weights from JSON files

### DIFF
--- a/include/reweighting.hxx
+++ b/include/reweighting.hxx
@@ -6,6 +6,11 @@ ROOT::RDF::RNode puweights(ROOT::RDF::RNode df, const std::string &weightname,
                            const std::string &truePUMean,
                            const std::string &filename,
                            const std::string &histogramname);
+ROOT::RDF::RNode puweights(ROOT::RDF::RNode df, const std::string &weightname,
+                           const std::string &truePU,
+                           const std::string &filename,
+                           const std::string &eraname,
+                           const std::string &variation);
 ROOT::RDF::RNode topptreweighting(ROOT::RDF::RNode df,
                                   const std::string &weightname,
                                   const std::string &gen_pdgids,


### PR DESCRIPTION
New producer for PU weights, the weight are directly from the LUM POG json files, e.g. `data/jsonpog-integration/POG/LUM/2018_UL/puWeights.json.gz`

PR tested with `earlyrun3` workflow.