### PR TITLE
Add generic Producer to check dR overlap

### DIFF
--- a/include/basefunctions.hxx
+++ b/include/basefunctions.hxx
@@ -378,7 +378,7 @@ inline auto FilterJetID(const int &index) {
     return [index](const ROOT::RVec<Int_t> &IDs) {
         ROOT::RVec<int> mask = IDs >= index;
         Logger::get("FilterJetID")->debug("IDs: {}", IDs);
-         Logger::get("FilterJetID")->debug("Filtered mask: {}", mask);
+        Logger::get("FilterJetID")->debug("Filtered mask: {}", mask);
         return mask;
     };
 }

--- a/include/physicsobjects.hxx
+++ b/include/physicsobjects.hxx
@@ -63,6 +63,11 @@ ROOT::RDF::RNode CutNFlag(ROOT::RDF::RNode df, const std::string &outputname,
 ROOT::RDF::RNode SelectedObjects(ROOT::RDF::RNode df,
                                  const std::string &outputname,
                                  const std::string &inputmaskname);
+ROOT::RDF::RNode DeltaRParticleVeto(
+    ROOT::RDF::RNode df, const std::string &output_flag, const std::string &p4,
+    const std::string &particle_mask, const std::string &particle_pt,
+    const std::string &particle_eta, const std::string &particle_phi,
+    const std::string &particle_mass, const float dR_cut);
 ROOT::RDF::RNode ObjectMassCorrectionWithPt(ROOT::RDF::RNode df,
                                             const std::string &corrected_mass,
                                             const std::string &raw_mass,

--- a/include/scalefactors.hxx
+++ b/include/scalefactors.hxx
@@ -98,12 +98,14 @@ ROOT::RDF::RNode muon_sf(ROOT::RDF::RNode df, const std::string &pt,
                          const std::string &eta, const std::string &output,
                          const std::string &sf_file,
                          const std::string correctiontype,
-                         const std::string &idAlgorithm);
+                         const std::string &idAlgorithm,
+                         const float &extrapolation_factor = 1.0);
 ROOT::RDF::RNode electron_sf(ROOT::RDF::RNode df, const std::string &pt,
                              const std::string &eta, const std::string &output,
                              const std::string &sf_file,
                              const std::string correctiontype,
-                             const std::string &idAlgorithm);
+                             const std::string &idAlgorithm,
+                             const float &extrapolation_factor = 1.0);
 } // namespace embedding
 } // namespace scalefactor
 #endif /* GUARD_SCALEFACTORS_H */

--- a/src/jets.cxx
+++ b/src/jets.cxx
@@ -36,7 +36,8 @@ VetoOverlappingJets(ROOT::RDF::RNode df, const std::string &output_col,
                     const ROOT::RVec<float> &jet_phi,
                     const ROOT::Math::PtEtaPhiMVector &p4_1,
                     const ROOT::Math::PtEtaPhiMVector &p4_2) {
-            Logger::get("VetoOverlappingJets (2 particles)")->debug("Checking jets");
+            Logger::get("VetoOverlappingJets (2 particles)")
+                ->debug("Checking jets");
             ROOT::RVec<int> mask(jet_eta.size(), 1);
             for (std::size_t idx = 0; idx < mask.size(); ++idx) {
                 ROOT::Math::RhoEtaPhiVectorF jet(0, jet_eta.at(idx),
@@ -58,7 +59,7 @@ VetoOverlappingJets(ROOT::RDF::RNode df, const std::string &output_col,
                 mask[idx] = (deltaR_1 > deltaRmin && deltaR_2 > deltaRmin);
             }
             Logger::get("VetoOverlappingJets (2 particles)")
-                    ->debug("vetomask due to overlap: {}", mask);
+                ->debug("vetomask due to overlap: {}", mask);
             return mask;
         },
         {jet_eta, jet_phi, p4_1, p4_2});
@@ -99,7 +100,7 @@ VetoOverlappingJets(ROOT::RDF::RNode df, const std::string &output_col,
                 mask[idx] = (deltaR_1 > deltaRmin);
             }
             Logger::get("VetoOverlappingJets")
-                    ->debug("vetomask due to overlap: {}", mask);
+                ->debug("vetomask due to overlap: {}", mask);
             return mask;
         },
         {jet_eta, jet_phi, p4_1});

--- a/src/physicsobjects.cxx
+++ b/src/physicsobjects.cxx
@@ -286,7 +286,7 @@ ROOT::RDF::RNode DeltaRParticleVeto(
     const std::string &particle_mask, const std::string &particle_pt,
     const std::string &particle_eta, const std::string &particle_phi,
     const std::string &particle_mass, const float dR_cut) {
-    auto veto_overlapping_photon =
+    auto veto_overlapping_particle =
         [dR_cut](const ROOT::Math::PtEtaPhiMVector &p4,
                  const ROOT::RVec<float> &particle_pt,
                  const ROOT::RVec<float> &particle_eta,
@@ -316,7 +316,7 @@ ROOT::RDF::RNode DeltaRParticleVeto(
             // if no particle is close enough to the p4, return false
             return false;
         };
-    auto df1 = df.Define(output_flag, veto_overlapping_photon,
+    auto df1 = df.Define(output_flag, veto_overlapping_particle,
                          {p4, particle_pt, particle_eta, particle_phi,
                           particle_mass, particle_mask});
     return df1;

--- a/src/scalefactors.cxx
+++ b/src/scalefactors.cxx
@@ -855,25 +855,31 @@ ROOT::RDF::RNode selection_id(ROOT::RDF::RNode df, const std::string &pt,
  * `mc` for monte carlo
  * @param idAlgorithm the name of the scale factor in the correctionlib
  * file
+ * @param extrapolation_factor The extrapolation factor to be used for the scale
+ * factor, defaults to 1.
  * @return ROOT::RDF::RNode
  */
 ROOT::RDF::RNode muon_sf(ROOT::RDF::RNode df, const std::string &pt,
                          const std::string &eta, const std::string &output,
                          const std::string &sf_file,
                          const std::string correctiontype,
-                         const std::string &idAlgorithm) {
+                         const std::string &idAlgorithm,
+                         const float &extrapolation_factor = 1.0) {
 
     Logger::get("EmbeddingMuonSF")->debug("Correction - Name {}", idAlgorithm);
     auto evaluator =
         correction::CorrectionSet::from_file(sf_file)->at(idAlgorithm);
     auto df1 = df.Define(
         output,
-        [evaluator, correctiontype](const float &pt, const float &eta) {
+        [evaluator, correctiontype, extrapolation_factor](const float &pt,
+                                                          const float &eta) {
             Logger::get("EmbeddingMuonSF")
-                ->debug(" pt {}, eta {}, correctiontype {}", pt, eta,
-                        correctiontype);
+                ->debug(" pt {}, eta {}, correctiontype {}, extrapolation "
+                        "factor {}",
+                        pt, eta, correctiontype, extrapolation_factor);
             double sf = 1.;
-            sf = evaluator->evaluate({pt, std::abs(eta), correctiontype});
+            sf = extrapolation_factor *
+                 evaluator->evaluate({pt, std::abs(eta), correctiontype});
             Logger::get("EmbeddingMuonSF")->debug("sf {}", sf);
             return sf;
         },
@@ -893,13 +899,16 @@ ROOT::RDF::RNode muon_sf(ROOT::RDF::RNode df, const std::string &pt,
  * `mc` for monte carlo
  * @param idAlgorithm the name of the scale factor in the correctionlib
  * file
+ * @param extrapolation_factor The extrapolation factor to be used for the scale
+ * factor, defaults to 1.
  * @return ROOT::RDF::RNode
  */
 ROOT::RDF::RNode electron_sf(ROOT::RDF::RNode df, const std::string &pt,
                              const std::string &eta, const std::string &output,
                              const std::string &sf_file,
                              const std::string correctiontype,
-                             const std::string &idAlgorithm) {
+                             const std::string &idAlgorithm,
+                             const float &extrapolation_factor = 1.0) {
 
     Logger::get("EmbeddingElectronSF")
         ->debug("Correction - Name {}", idAlgorithm);
@@ -907,12 +916,15 @@ ROOT::RDF::RNode electron_sf(ROOT::RDF::RNode df, const std::string &pt,
         correction::CorrectionSet::from_file(sf_file)->at(idAlgorithm);
     auto df1 = df.Define(
         output,
-        [evaluator, correctiontype](const float &pt, const float &eta) {
+        [evaluator, correctiontype, extrapolation_factor](const float &pt,
+                                                          const float &eta) {
             Logger::get("EmbeddingElectronSF")
-                ->debug(" pt {}, eta {}, correctiontype {}", pt, eta,
-                        correctiontype);
+                ->debug(" pt {}, eta {}, correctiontype {}, extrapolation "
+                        "factor {}",
+                        pt, eta, correctiontype, extrapolation_factor);
             double sf = 1.;
-            sf = evaluator->evaluate({pt, std::abs(eta), correctiontype});
+            sf = extrapolation_factor *
+                 evaluator->evaluate({pt, std::abs(eta), correctiontype});
             Logger::get("EmbeddingElectronSF")->debug("sf {}", sf);
             return sf;
         },


### PR DESCRIPTION
This PR adds a Producer that can be used to generate a veto boolean, if a given p4 vector is overlapping with any particle within a collection.

One possible example is a FSR photon veto, where a p4 vector can be checked against all photons passing a selection