### PR TITLE
add exeption for misconfiguration of sampleypes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,7 +45,7 @@ jobs:
       - name: install packages
         run: apt-get install -y git cmake make python3-pip openmpi-bin libopenmpi-dev libboost-all-dev openssh-client
       - name: install python packages
-        run: python3 -m pip install GitPython --break-system-packages && python3 -m pip install git+https://github.com/cms-nanoAOD/correctionlib.git --break-system-packages
+        run: python3 -m pip install GitPython && python3 -m pip install git+https://github.com/cms-nanoAOD/correctionlib.git
 
       - name: Clone project
         uses: actions/checkout@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,7 +43,7 @@ jobs:
       - name: update ubuntu
         run: apt-get -y update
       - name: install packages
-        run: apt-get install -y git cmake make python3-pip openmpi-bin libopenmpi-dev libboost-all-dev openssh-client
+        run: apt-get install -y git cmake make python3-pip openmpi-bin libopenmpi-dev libboost-all-dev openssh-client nlohmann-json3-dev
       - name: install python packages
         run: python3 -m pip install GitPython && python3 -m pip install git+https://github.com/cms-nanoAOD/correctionlib.git
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,7 +43,7 @@ jobs:
       - name: update ubuntu
         run: apt-get -y update
       - name: install packages
-        run: apt-get install -y git cmake make python3-pip openmpi-bin libopenmpi-dev libboost-all-dev openssh-client nlohmann-json3-dev
+        run: apt-get install -y git cmake make python3-pip openmpi-bin libopenmpi-dev libboost-all-dev openssh-client
       - name: install python packages
         run: python3 -m pip install GitPython && python3 -m pip install git+https://github.com/cms-nanoAOD/correctionlib.git
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,18 +27,25 @@ jobs:
   build_project:
     runs-on: ubuntu-20.04
     container:
-      image: rootproject/root:6.28.04-arch
+      image: rootproject/root:6.30.02-ubuntu22.04
       options: --user 0 # run as root
 
     steps:
-      - name: update Arch keyring
-        run: pacman -Sc --noconfirm && pacman -Syy --noconfirm && pacman -Sy archlinux-keyring --noconfirm
+      # - name: update Arch keyring
+      #   run: pacman -Sc --noconfirm && pacman -Syy --noconfirm && pacman -Sy archlinux-keyring --noconfirm
 
-      - name: Install missing software
-        run: pacman -Syu --noconfirm cmake make git python-pip openmp openmpi boost openssh --ignore root --ignore openssl
+      # - name: Install missing software
+      #   run: pacman -Syu --noconfirm cmake make git python-pip openmp openmpi boost openssh --ignore root --ignore openssl
 
-      - name: Install python packages
-        run: python -m pip install GitPython --break-system-packages && python -m pip install git+https://github.com/cms-nanoAOD/correctionlib.git --break-system-packages
+      # - name: Install python packages
+      #   run: python -m pip install GitPython --break-system-packages && python -m pip install git+https://github.com/cms-nanoAOD/correctionlib.git --break-system-packages
+
+      - name: update ubuntu
+        run: apt-get -y update
+      - name: install packages
+        run: apt-get install -y git cmake make python3-pip openmpi-bin libopenmpi-dev libboost-all-dev openssh-client
+      - name: install python packages
+        run: python3 -m pip install GitPython --break-system-packages && python3 -m pip install git+https://github.com/cms-nanoAOD/correctionlib.git --break-system-packages
 
       - name: Clone project
         uses: actions/checkout@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
   build_project:
     runs-on: ubuntu-20.04
     container:
-      image: rootproject/root:6.30.02-ubuntu22.04
+      image: rootproject/root:6.28.10-ubuntu22.04
       options: --user 0 # run as root
 
     steps:

--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -173,6 +173,11 @@ int main(int argc, char *argv[]) {
             cutflow.SetTitle("cutflow");
             // iterate through the cutflow vector and fill the histogram with the
             // .GetPass() values
+            if (scope_counter >= cutReports.size()) {
+                Logger::get("main")->critical(
+                    "Cutflow vector is too small, this should not happen");
+                return 1;
+            }
             for (auto cut = cutReports[scope_counter].begin();
                 cut != cutReports[scope_counter].end(); cut++) {
                 cutflow.SetBinContent(

--- a/code_generation/code_generation.py
+++ b/code_generation/code_generation.py
@@ -764,7 +764,7 @@ class CodeGenerator(object):
                     global_commands = []
                 outputset = list(set(self.output_commands[scope] + global_commands))
                 # now split by __ and get a set of all the shifts per variable
-                for i, output in enumerate(outputset):
+                for output in outputset:
                     try:
                         quantity, shift = output.split("__")
                     except ValueError:

--- a/code_generation/configuration.py
+++ b/code_generation/configuration.py
@@ -316,7 +316,7 @@ class Configuration(object):
         self,
         shift: Union[SystematicShift, SystematicShiftByQuantity],
         samples: Union[str, List[str], None] = None,
-        excluded_samples: Union[str, List[str], None] = None,
+        exclude_samples: Union[str, List[str], None] = None,
     ) -> None:
         """
         Function used to add a systematics shift to the configuration. During this step, the shift is validated and applied.
@@ -325,14 +325,14 @@ class Configuration(object):
             shift: The shift to be added. This must be a SystematicShift object.
             samples: The samples to which the shift should be applied. This can be a list of samples or a single sample.
                 If ths option is not set, the shift is applied, regardless of the sample type.
-            excluded_samples: The samples to which the shift should not be applied. This can be a list of samples or a single sample. if excluded_samples is set, samples cannot be used.
+            exclude_samples: The samples to which the shift should not be applied. This can be a list of samples or a single sample. if exclude_samples is set, samples cannot be used.
 
         Returns:
             None
         """
-        if excluded_samples is not None and samples is not None:
+        if exclude_samples is not None and samples is not None:
             raise ConfigurationError(
-                f"You cannot use samples and excluded_samples at the same time -> Shift {shift}, samples {samples}, excluded_samples {excluded_samples}"
+                f"You cannot use samples and exclude_samples at the same time -> Shift {shift}, samples {samples}, exclude_samples {exclude_samples}"
             )
         if samples is not None:
             if isinstance(samples, str):
@@ -342,15 +342,15 @@ class Configuration(object):
                     raise ConfigurationError(
                         f"Sampletype {sample} is not available -> Shift {shift}, available_sample_types {self.available_sample_types}, sample_types {samples}"
                     )
-        if excluded_samples is not None:
-            if isinstance(excluded_samples, str):
-                excluded_samples = [excluded_samples]
-            for excluded_sample in excluded_samples:
+        if exclude_samples is not None:
+            if isinstance(exclude_samples, str):
+                exclude_samples = [exclude_samples]
+            for excluded_sample in exclude_samples:
                 if excluded_sample not in self.available_sample_types:
                     raise ConfigurationError(
-                        f"Sampletype {excluded_sample} is not available for exclusion -> Shift {shift}, available_sample_types {self.available_sample_types}, excluded_sample_types {excluded_samples}"
+                        f"Sampletype {excluded_sample} is not available for exclusion -> Shift {shift}, available_sample_types {self.available_sample_types}, excluded_sample_types {exclude_samples}"
                     )
-            samples = list(self.available_sample_types - set(excluded_samples))
+            samples = list(self.available_sample_types - set(exclude_samples))
         if self._is_valid_shift(shift):
             log.debug("Shift {} is valid".format(shift.shiftname))
             if not isinstance(shift, SystematicShift):

--- a/code_generation/configuration.py
+++ b/code_generation/configuration.py
@@ -431,6 +431,7 @@ class Configuration(object):
             scopes = [scopes]
         rule.set_scopes(scopes)
         rule.set_global_scope(self.global_scope)
+        rule.validate_samples(self.available_sample_types)
         self.rules.add(rule)
 
     def resolve_modifiers(self, configuration_dict: Dict[Any, Any]) -> TConfiguration:

--- a/code_generation/exceptions.py
+++ b/code_generation/exceptions.py
@@ -69,7 +69,7 @@ class SampleRuleConfigurationError(ConfigurationError):
     def __init__(
         self,
         sample: str,
-        rule: "ProducerRule",
+        rule,
         available_samples: Union[Set[str], List[str]],
     ):
         self.message = "Sampletype {} cannot be used in Rule {} since the type is not defined. Available samples types are {}".format(

--- a/code_generation/exceptions.py
+++ b/code_generation/exceptions.py
@@ -61,6 +61,23 @@ class SampleConfigurationError(ConfigurationError):
         super().__init__(self.message)
 
 
+class SampleRuleConfigurationError(ConfigurationError):
+    """
+    Exception raised when the sample type used for a Rule provided by the user is not valid.
+    """
+
+    def __init__(
+        self,
+        sample: str,
+        rule: "ProducerRule",
+        available_samples: Union[Set[str], List[str]],
+    ):
+        self.message = "Sampletype {} cannot be used in Rule {} since the type is not defined. Available samples types are {}".format(
+            sample, rule, available_samples
+        )
+        super().__init__(self.message)
+
+
 class EraConfigurationError(ConfigurationError):
     """
     Exception raised when the era configuration provided by the user is not valid.

--- a/code_generation/friend_trees.py
+++ b/code_generation/friend_trees.py
@@ -396,6 +396,7 @@ class FriendTreeConfiguration(Configuration):
             raise TypeError("Rule must be of type ProducerRule")
         if not isinstance(scopes, list):
             scopes = [scopes]
+        rule.set_available_sampletypes(self.available_sample_types)
         rule.set_scopes(scopes)
         # TODO Check if this works without a global scope
         if self.global_scope is not None:

--- a/code_generation/friend_trees.py
+++ b/code_generation/friend_trees.py
@@ -303,9 +303,12 @@ class FriendTreeConfiguration(Configuration):
             # only shift if necessary
             if shift in self.input_quantities_mapping[scope].keys():
                 inputs_to_shift = []
-                for input in inputs:
-                    if input.name in self.input_quantities_mapping[scope][shift]:
-                        inputs_to_shift.append(input)
+                for input_quantity in inputs:
+                    if (
+                        input_quantity.name
+                        in self.input_quantities_mapping[scope][shift]
+                    ):
+                        inputs_to_shift.append(input_quantity)
                 if len(inputs_to_shift) > 0:
                     log.debug("Adding shift %s to producer %s", shift, producer)
                     producer.shift(shiftname, scope)
@@ -335,7 +338,7 @@ class FriendTreeConfiguration(Configuration):
         for scope in [scope for scope in self.scopes]:
             required_outputs = set(output for output in self.outputs[scope])
             # merge the two sets of outputs
-            provided_outputs = self.available_outputs[scope]
+            provided_outputs = self.available_outputs[scope][self.sample]
             missing_outputs = required_outputs - provided_outputs
             if len(missing_outputs) > 0:
                 raise InvalidOutputError(scope, missing_outputs)
@@ -415,6 +418,10 @@ class FriendTreeConfiguration(Configuration):
             expanded_configuration[scope] = {}
             if self.run_nominal:
                 log.debug("Adding nominal in scope {}".format(scope))
+                if scope not in self.config_parameters.keys():
+                    raise ConfigurationError(
+                        "Scope {} not found in configuration parameters".format(scope)
+                    )
                 expanded_configuration[scope]["nominal"] = self.config_parameters[scope]
             if len(self.shifts[scope]) > 0:
                 for shift in self.shifts[scope]:

--- a/code_generation/rules.py
+++ b/code_generation/rules.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union
+from typing import List, Union, Set
 
 from code_generation.producer import (
     CollectProducersOutput,
@@ -9,6 +9,7 @@ from code_generation.producer import (
     TProducerStore,
 )
 from code_generation.quantity import QuantitiesStore
+from code_generation.exceptions import SampleRuleConfigurationError
 
 log = logging.getLogger(__name__)
 
@@ -57,6 +58,19 @@ class ProducerRule:
 
     def set_global_scope(self, global_scope: str) -> None:
         self.global_scope = global_scope
+
+    def validate_samples(self, available_samples: Set[str]) -> None:
+        """Function to check, if a rule is applicable, or if one of the defined samples is not available.
+
+        Args:
+            available_samples (List[str]): List of available samples.
+
+        Returns:
+            None
+        """
+        for sample in self.samples:
+            if sample not in available_samples:
+                raise SampleRuleConfigurationError(sample, self, available_samples)
 
     # Evaluate whether modification should be applied depending on sample and inversion flag
     def is_applicable(self, sample: str) -> bool:

--- a/code_generation/rules.py
+++ b/code_generation/rules.py
@@ -127,6 +127,7 @@ class ProducerRule:
         outputs_to_be_updated: QuantitiesStore,
     ) -> None:
         if self.is_applicable(sample):
+            log.critical(f"Applying rule {self} for sample {sample}")
             log.debug("For sample {}, applying >> {} ".format(sample, self))
             self.update_producers(producers_to_be_updated, unpacked_producers)
             self.update_outputs(outputs_to_be_updated)

--- a/code_generation/rules.py
+++ b/code_generation/rules.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union, Set
+from typing import List, Union
 
 from code_generation.producer import (
     CollectProducersOutput,

--- a/code_generation/rules.py
+++ b/code_generation/rules.py
@@ -19,7 +19,7 @@ class ProducerRule:
         self,
         producers: TProducerInput,
         samples: Union[str, List[str]] = [],
-        excluded_samples: Union[str, List[str]] = [],
+        exclude_samples: Union[str, List[str]] = [],
         scopes: Union[str, List[str]] = "global",
         invert: bool = False,
         update_output: bool = True,
@@ -28,8 +28,8 @@ class ProducerRule:
 
         Args:
             producers: A list of producers or producer groups to be modified.
-            samples: A list of samples, for which the rule should be applied. Only one of samples and excluded_samples can be defined.
-            excluded_samples: A list of samples, for which the rule should not be applied. Only one of samples and excluded_samples can be defined.
+            samples: A list of samples, for which the rule should be applied. Only one of samples and exclude_samples can be defined.
+            exclude_samples: A list of samples, for which the rule should not be applied. Only one of samples and exclude_samples can be defined.
             scopes: The scopes, in which the rule should be applied. Defaults to "global".
             invert: If set, the invert of the rule is applied. Defaults to False.
             update_output: If set, the output quantities are updated. Defaults to True.
@@ -43,10 +43,10 @@ class ProducerRule:
         self.invert = invert
         self.update_output = update_output
         self.global_scope = "global"
-        if isinstance(excluded_samples, str):
-            self.excluded_samples = [excluded_samples]
+        if isinstance(exclude_samples, str):
+            self.exclude_samples = [exclude_samples]
         else:
-            self.excluded_samples = excluded_samples
+            self.exclude_samples = exclude_samples
         if isinstance(samples, str):
             self.samples = [samples]
         else:
@@ -58,23 +58,21 @@ class ProducerRule:
             self.available_samples = [available_samples]
         else:
             self.available_samples = available_samples
-        # make sure that either samples or excluded_samples are defined
-        if self.excluded_samples == [] and self.samples == []:
+        # make sure that either samples or exclude_samples are defined
+        if self.exclude_samples == [] and self.samples == []:
             raise ValueError(
-                f"ProducerRule: Either samples or excluded_samples have to be defined!: (Rule: {self}, Samples: {self.samples}, Excluded Samples: {self.excluded_samples})"
+                f"ProducerRule: Either samples or exclude_samples have to be defined!: (Rule: {self}, Samples: {self.samples}, Excluded Samples: {self.exclude_samples})"
             )
-        if self.excluded_samples != [] and self.samples != []:
+        if self.exclude_samples != [] and self.samples != []:
             raise ValueError(
-                f"ProducerRule: Both samples and are excluded_samples are defined, pick one!: (Rule: {self}, Samples: {self.samples}, Excluded Samples: {self.excluded_samples})"
+                f"ProducerRule: Both samples and are exclude_samples are defined, pick one!: (Rule: {self}, Samples: {self.samples}, Excluded Samples: {self.exclude_samples})"
             )
         # make sure that the sampletypes are valid
         self.validate_sampletypes(self.samples)
-        self.validate_sampletypes(self.excluded_samples)
-        # if excluded_samples are defined, we have to contstruct the list of samples them from the list of available samples
-        if self.excluded_samples != []:
-            self.samples = list(
-                set(self.available_samples) - set(self.excluded_samples)
-            )
+        self.validate_sampletypes(self.exclude_samples)
+        # if exclude_samples are defined, we have to contstruct the list of samples them from the list of available samples
+        if self.exclude_samples != []:
+            self.samples = list(set(self.available_samples) - set(self.exclude_samples))
 
     def set_scopes(self, scopes: List[str]) -> None:
         if isinstance(scopes, str):


### PR DESCRIPTION
Now, CROWN will throw an error during configuration, when a rule is configured to be applied to a nonexistent sampletype:

```
code_generation.exceptions.SampleRuleConfigurationError: Sampletype embedding,embedding_mc cannot be used in Rule ProducerRule - add [ProducerGroup: RenameJetsData] for ['embedding,embedding_mc'] in scopes ['global'] since the type is not defined. Available samples types are {'ttbar', 'embedding', 'embedding_mc', 'wjets', 'singletop', 'data', 'ggh_hbb', 'vbf_hbb', 'rem_hbb', 'dyjets', 'diboson', 'rem_htautau', 'ggh_htautau', 'vbf_htautau', 'electroweak_boson'}
CMake Error at CMakeLists.txt:338 (message):
  Code Generation Failed - Exiting !
  ```