### PR TITLE
add additional check if ntuple tree is empty

### DIFF
--- a/code_generation/analysis_template_friends.cxx
+++ b/code_generation/analysis_template_friends.cxx
@@ -59,9 +59,16 @@ int validate_rootfile(std::string file, std::string &basetree) {
         Logger::get("main")->info("CROWN input_file: {} - {} Events", file,
                                   t1->GetEntries());
         return nevents;
+    } else if (list->FindObject("quantities")) {
+        TTree *t1 = (TTree *)f1->Get("quantities");
+        nevents += t1->GetEntries();
+        basetree = "ntuple";
+        Logger::get("main")->critical("CROWN input_file: {} - {} Events", file,
+                                  t1->GetEntries());
+        return nevents;
     } else {
         Logger::get("main")->critical("File {} does not contain a tree "
-                                      "named 'Events' or 'ntuple'",
+                                      "named 'Events' or 'ntuple' or 'quantities'",
                                       file);
         return -1;
     }
@@ -161,9 +168,11 @@ int main(int argc, char *argv[]) {
     ROOT::RDataFrame df0(dataset);
     ROOT::RDF::Experimental::AddProgressBar(df0); // add progress bar
     // print all available branches to the log
-    Logger::get("main")->debug("Available branches:");
-    for (auto const &branch : df0.GetColumnNames()) {
-        Logger::get("main")->debug("{}", branch);
+    if (nevents != 0) {
+        Logger::get("main")->debug("Available branches:");
+        for (auto const &branch : df0.GetColumnNames()) {
+            Logger::get("main")->debug("{}", branch);
+        }
     }
     Logger::get("main")->info(
         "Starting Setup of Dataframe with {} events and {} friends", nevents,


### PR DESCRIPTION
This PR is addressing https://github.com/KIT-CMS/CROWN/issues/268

If a ntuple is processed but has no events left after all applied filters, the ntuple file does not contain a `ntuple` tree because it seems that the `rdf.Snapshot()` function does not write out  a tree if it's empty. This leads to the problem that friend production fails for these ntuples although they were processed correctly. To account for this an additional check is added to look at the `quantities` tree. This tree is saved even if the event number is 0 since it is not done by `rdf.Snapshot()`.