### PR TITLE
Adding the functionality to include analysis specific c++ code to CROWN

### DIFF
--- a/cmake/ConfigureCrownlib.cmake
+++ b/cmake/ConfigureCrownlib.cmake
@@ -1,11 +1,18 @@
 # build a shared lib from all CROWN functions
 include_directories(${CMAKE_SOURCE_DIR}/src)
 include_directories(${CMAKE_SOURCE_DIR}/include)
+
+include_directories(${CMAKE_SOURCE_DIR}/analysis_configurations/*/cpp_addons/src)
+include_directories(${CMAKE_SOURCE_DIR}/analysis_configurations/*/cpp_addons/include)
+
 file(GLOB SOURCES_1 ${CMAKE_SOURCE_DIR}/src/*.cxx)
 file(GLOB SOURCES_2 ${CMAKE_SOURCE_DIR}/src/utility/*.cxx
      ${CMAKE_SOURCE_DIR}/src/RecoilCorrections/*.cxx
      ${CMAKE_SOURCE_DIR}/src/SVFit/*.cxx)
-set(SOURCES ${SOURCES_1} ${SOURCES_2})
+
+file(GLOB SOURCES_3 ${CMAKE_SOURCE_DIR}/analysis_configurations/*/cpp_addons/src/*.cxx)
+
+set(SOURCES ${SOURCES_1} ${SOURCES_2} ${SOURCES_3})
 
 if(BUILD_CROWNLIB_ONLY)
   message(STATUS "Building only the CROWNLIB library")

--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -32,6 +32,8 @@
 #include "include/triggers.hxx"
 #include "include/fakefactors.hxx"
 
+// {INCLUDE_ANALYSISADDONS}
+
 // {INCLUDES}
 
 int main(int argc, char *argv[]) {

--- a/code_generation/analysis_template_friends.cxx
+++ b/code_generation/analysis_template_friends.cxx
@@ -32,6 +32,9 @@
 #include "include/topreco.hxx"
 #include "include/triggers.hxx"
 #include "include/tripleselection.hxx"
+
+// {INCLUDE_ANALYSISADDONS}
+
 // {INCLUDES}
 
 int validate_rootfile(std::string file, std::string &basetree) {

--- a/code_generation/code_generation.py
+++ b/code_generation/code_generation.py
@@ -324,6 +324,16 @@ class CodeGenerator(object):
             template = template_file.read()
         return template
 
+    def addon_includes(self):
+        path = f"analysis_configurations/{self.analysis_name}/cpp_addons/include"
+        if os.path.exists(path) and os.path.isdir(path) and os.listdir(path):
+            log.info(f"Adding addons from {path}: {' '.join(os.listdir(path))}")
+            paths = "\n".join(f'#include "{os.path.join(path, item)}"' for item in os.listdir(path))
+            return paths
+        else:
+            log.info(f"No addons found in {path}")
+            return ""
+
     def write_code(self, calls: str, includes: str, run_commands: str) -> None:
         """
         Write the code of the main executable to the output folder
@@ -350,6 +360,7 @@ class CodeGenerator(object):
                     "        // {ZERO_EVENTS_FALLBACK}", self.zero_events_fallback()
                 )
                 .replace("        // {CODE_GENERATION}", calls)
+                .replace("// {INCLUDE_ANALYSISADDONS}", self.addon_includes())
                 .replace("// {INCLUDES}", includes)
                 .replace("        // {RUN_COMMANDS}", run_commands)
                 .replace("// {MULTITHREADING}", threadcall)

--- a/code_generation/subset_template.cxx
+++ b/code_generation/subset_template.cxx
@@ -31,6 +31,9 @@
 #include "include/topreco.hxx"
 #include "include/triggers.hxx"
 #include "include/fakefactors.hxx"
+
+// {INCLUDE_ANALYSISADDONS}
+
 ROOT::RDF::RNode {subsetname} (ROOT::RDF::RNode df0, OnnxSessionManager &onnxSessionManager, correctionManager::CorrectionManager &correctionManager) {
 
     //    { commands }


### PR DESCRIPTION
Addition of functionality to offload c++ specific code to analysis specific configurations stored in `cpp_addons/include` and `cpp_addons/src`


Things that need to be done:
  [ ] Documentation on what to look for when using this functionality
  [ ] finding a better name?
  [ ] checking if this is a good enough solution