### PR TITLE
Allow for one subfolder in cpp_addons

### DIFF
--- a/cmake/ConfigureCrownlib.cmake
+++ b/cmake/ConfigureCrownlib.cmake
@@ -7,9 +7,7 @@ include_directories(${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_
 
 file(GLOB SOURCES_1 
   ${CMAKE_SOURCE_DIR}/src/*.cxx
-  ${CMAKE_SOURCE_DIR}/src/utility/*.cxx
-  ${CMAKE_SOURCE_DIR}/src/RecoilCorrections/*.cxx
-  ${CMAKE_SOURCE_DIR}/src/SVFit/*.cxx)
+  ${CMAKE_SOURCE_DIR}/src/*/*.cxx)
 
 file(GLOB SOURCES_2 
   ${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/src/*.cxx

--- a/cmake/ConfigureCrownlib.cmake
+++ b/cmake/ConfigureCrownlib.cmake
@@ -5,14 +5,17 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/src)
 include_directories(${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/include)
 
-file(GLOB SOURCES_1 ${CMAKE_SOURCE_DIR}/src/*.cxx)
-file(GLOB SOURCES_2 ${CMAKE_SOURCE_DIR}/src/utility/*.cxx
-     ${CMAKE_SOURCE_DIR}/src/RecoilCorrections/*.cxx
-     ${CMAKE_SOURCE_DIR}/src/SVFit/*.cxx)
+file(GLOB SOURCES_1 
+  ${CMAKE_SOURCE_DIR}/src/*.cxx
+  ${CMAKE_SOURCE_DIR}/src/utility/*.cxx
+  ${CMAKE_SOURCE_DIR}/src/RecoilCorrections/*.cxx
+  ${CMAKE_SOURCE_DIR}/src/SVFit/*.cxx)
 
-file(GLOB SOURCES_3 ${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/src/*.cxx ${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/src/*/*.cxx)
+file(GLOB SOURCES_2 
+  ${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/src/*.cxx
+  ${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/src/*/*.cxx)
 
-set(SOURCES ${SOURCES_1} ${SOURCES_2} ${SOURCES_3})
+set(SOURCES ${SOURCES_1} ${SOURCES_2})
 
 if(BUILD_CROWNLIB_ONLY)
   message(STATUS "Building only the CROWNLIB library")

--- a/cmake/ConfigureCrownlib.cmake
+++ b/cmake/ConfigureCrownlib.cmake
@@ -10,7 +10,7 @@ file(GLOB SOURCES_2 ${CMAKE_SOURCE_DIR}/src/utility/*.cxx
      ${CMAKE_SOURCE_DIR}/src/RecoilCorrections/*.cxx
      ${CMAKE_SOURCE_DIR}/src/SVFit/*.cxx)
 
-file(GLOB SOURCES_3 ${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/src/*.cxx)
+file(GLOB SOURCES_3 ${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/src/*.cxx ${CMAKE_SOURCE_DIR}/analysis_configurations/${ANALYSIS}/cpp_addons/src/*/*.cxx)
 
 set(SOURCES ${SOURCES_1} ${SOURCES_2} ${SOURCES_3})
 


### PR DESCRIPTION
Allow the folder structure in `analysis_configurations/<analysis>/cpp_addons/src` to have depth 1, for instance:

```
|- cpp_addons
   |- src
      |- HHKinFit
         |- file_1.cxx
         ...
      |- hhkinfit.cxx
```