### PR TITLE
Adding the new XYHbbtautau analysis repo

### DIFF
--- a/docs/sphinx_source/index.rst
+++ b/docs/sphinx_source/index.rst
@@ -26,7 +26,7 @@ The following analysis configurations are currently available in CROWN. If you w
    * - H to TauTau
      - https://github.com/KIT-CMS/TauAnalysis-CROWN
    * - BSM di-Higgs to TauTauBB
-     - https://github.com/KIT-CMS/TauAnalysis-CROWN/tree/nmssm_devs
+     - https://github.com/KIT-CMS/XYHBBTauTauAnalysis-CROWN
    * - W/Z early Run3
      - https://github.com/KIT-CMS/earlyRun3Analysis-CROWN
    * - W + H to TauTau

--- a/docs/sphinx_source/introduction.rst
+++ b/docs/sphinx_source/introduction.rst
@@ -64,6 +64,8 @@ The following list shows all currently available analyses that can be set up. If
      - https://github.com/KIT-CMS/BoostedHiggsTauTauAnalysis-CROWN
    * - ``s``
      - https://github.com/nfaltermann/CROWNs
+   * - ``XYHbbtautau``
+     - https://github.com/KIT-CMS/XYHBBTauTauAnalysis-CROWN
 
 Running the framework
 **********************

--- a/init.sh
+++ b/init.sh
@@ -81,5 +81,8 @@ else
     elif [[ "$1" == "s" && ! -d "${SCRIPT_DIR}/analysis_configurations/s" ]]; then
         echo "Cloning analysis s-channel into ${SCRIPT_DIR}/analysis_configurations/s"
         git clone git@github.com:nfaltermann/CROWNs.git "${SCRIPT_DIR}/analysis_configurations/s"
+    elif [[ "$1" == "XYHbbtautau" && ! -d "${SCRIPT_DIR}/analysis_configurations/XYHbbtautau" ]]; then
+        echo "Cloning analysis XYHbbtautau into ${SCRIPT_DIR}/analysis_configurations/XYHbbtautau"
+        git clone git@github.com:KIT-CMS/XYHBBTauTauAnalysis-CROWN.git "${SCRIPT_DIR}/analysis_configurations/XYHbbtautau"
     fi
 fi


### PR DESCRIPTION
This PR adds the new repository https://github.com/KIT-CMS/XYHBBTauTauAnalysis-CROWN of the X->YH->bbtautau analysis to CROWN. The analysis can now be loaded when CROWN is set up:
```bash
source init.sh XYHbbtautau
```