### PR TITLE
Updates for nanoAOD v9 and v12 compatibility

### DIFF
--- a/analysis_configurations/unittest/producers/pairquantities.py
+++ b/analysis_configurations/unittest/producers/pairquantities.py
@@ -270,7 +270,7 @@ taujet_pt_1 = Producer(
 )
 VsJetTauIDFlag_1 = ExtendedVectorProducer(
     name="VsJetTauIDFlag_1",
-    call="physicsobject::tau::quantity::IDFlag({df}, {output}, {input}, 0, {vsjet_tau_id_WPbit})",
+    call="physicsobject::tau::quantity::IDFlag_v9({df}, {output}, {input}, 0, {vsjet_tau_id_WPbit})",
     input=[nanoAOD.Tau_ID_vsJet, q.dileptonpair],
     output="tau_1_vsjet_id_outputname",
     scope=["tt"],
@@ -278,7 +278,7 @@ VsJetTauIDFlag_1 = ExtendedVectorProducer(
 )
 VsEleTauIDFlag_1 = ExtendedVectorProducer(
     name="VsEleTauIDFlag_1",
-    call="physicsobject::tau::quantity::IDFlag({df}, {output}, {input}, 0, {vsele_tau_id_WPbit})",
+    call="physicsobject::tau::quantity::IDFlag_v9({df}, {output}, {input}, 0, {vsele_tau_id_WPbit})",
     input=[nanoAOD.Tau_ID_vsEle, q.dileptonpair],
     output="tau_1_vsele_id_outputname",
     scope=["tt"],
@@ -286,7 +286,7 @@ VsEleTauIDFlag_1 = ExtendedVectorProducer(
 )
 VsMuTauIDFlag_1 = ExtendedVectorProducer(
     name="VsMuTauIDFlag_1",
-    call="physicsobject::tau::quantity::IDFlag({df}, {output}, {input}, 0, {vsmu_tau_id_WPbit})",
+    call="physicsobject::tau::quantity::IDFlag_v9({df}, {output}, {input}, 0, {vsmu_tau_id_WPbit})",
     input=[nanoAOD.Tau_ID_vsMu, q.dileptonpair],
     output="tau_1_vsmu_id_outputname",
     scope=["tt"],
@@ -316,7 +316,7 @@ taujet_pt_2 = Producer(
 )
 VsJetTauIDFlag_2 = ExtendedVectorProducer(
     name="VsJetTauIDFlag_2",
-    call="physicsobject::tau::quantity::IDFlag({df}, {output}, {input}, 1, {vsjet_tau_id_WPbit})",
+    call="physicsobject::tau::quantity::IDFlag_v9({df}, {output}, {input}, 1, {vsjet_tau_id_WPbit})",
     input=[nanoAOD.Tau_ID_vsJet, q.dileptonpair],
     output="tau_2_vsjet_id_outputname",
     scope=["et", "mt", "tt"],
@@ -324,7 +324,7 @@ VsJetTauIDFlag_2 = ExtendedVectorProducer(
 )
 VsEleTauIDFlag_2 = ExtendedVectorProducer(
     name="VsEleTauIDFlag_2",
-    call="physicsobject::tau::quantity::IDFlag({df}, {output}, {input}, 1, {vsele_tau_id_WPbit})",
+    call="physicsobject::tau::quantity::IDFlag_v9({df}, {output}, {input}, 1, {vsele_tau_id_WPbit})",
     input=[nanoAOD.Tau_ID_vsEle, q.dileptonpair],
     output="tau_2_vsele_id_outputname",
     scope=["et", "mt", "tt"],
@@ -332,7 +332,7 @@ VsEleTauIDFlag_2 = ExtendedVectorProducer(
 )
 VsMuTauIDFlag_2 = ExtendedVectorProducer(
     name="VsMuTauIDFlag_2",
-    call="physicsobject::tau::quantity::IDFlag({df}, {output}, {input}, 1, {vsmu_tau_id_WPbit})",
+    call="physicsobject::tau::quantity::IDFlag_v9({df}, {output}, {input}, 1, {vsmu_tau_id_WPbit})",
     input=[nanoAOD.Tau_ID_vsMu, q.dileptonpair],
     output="tau_2_vsmu_id_outputname",
     scope=["et", "mt", "tt"],

--- a/docs/sphinx_source/nanoAODversions.rst
+++ b/docs/sphinx_source/nanoAODversions.rst
@@ -196,6 +196,12 @@ Below is a list of known differences between nanoAODv9 and nanoAODv12.
      - Int_t -> Short_t
    * - Tau_decayMode
      - Int_t -> UChar_t
+   * - Tau_idDeepTau2017v2p1VSe
+     - same type, content changed
+   * - Tau_idDeepTau2017v2p1VSjet
+     - same type, content changed
+   * - Tau_idDeepTau2017v2p1VSmu
+     - same type, content changed
    * - Tau_jetIdx
      - Int_t -> Short_t
    * - Tau_genPartIdx
@@ -208,6 +214,16 @@ Below is a list of known differences between nanoAODv9 and nanoAODv12.
      - Int_t -> Short_t
    * - nTrigObj
      - UInt_t -> Int_t
+   * - boostedTau_idAntiEle2018
+     - same type, content changed
+   * - boostedTau_idAntiMu
+     - same type, content changed
+   * - boostedTau_idMVAnewDM2017v2
+     - same type, content changed
+   * - boostedTau_idMVAoldDM2017v2
+     - same type, content changed
+   * - boostedTau_idMVAoldDMdR032017v2
+     - same type, content changed
    * - boostedTau_jetIdx
      - Int_t -> Short_t
    * - boostedTau_rawAntiEleCat2018

--- a/include/event.hxx
+++ b/include/event.hxx
@@ -184,10 +184,10 @@ inline ROOT::RDF::RNode Get(ROOT::RDF::RNode df, const std::string &outputname,
                         // the static_cast is used because some types of nanoAOD 
                         // branches changed from Int_t to UChar_t for nanoAOD 
                         // versions > 9
-                        if constexpr (std::is_same<T, UChar_t>::value) {
+                        if constexpr (std::is_same<T, UChar_t>::value || std::is_same<T, Short_t>::value) {
                             int cast_result = static_cast<int>(result);
                             Logger::get("event::quantity::Get")
-                                ->debug("Returning UChar_t quantity as int: {}",
+                                ->debug("Returning UChar_t/Short_t quantity as int: {}",
                                         cast_result);
                             return cast_result;
                         } else {
@@ -234,10 +234,10 @@ inline ROOT::RDF::RNode Get(ROOT::RDF::RNode df, const std::string &outputname,
                         // the static_cast is used because some types of nanoAOD 
                         // branches changed from Int_t to UChar_t for nanoAOD 
                         // versions > 9
-                        if constexpr (std::is_same<T, UChar_t>::value) {
+                        if constexpr (std::is_same<T, UChar_t>::value || std::is_same<T, Short_t>::value) {
                             int cast_result = static_cast<int>(result);
                             Logger::get("event::quantity::Get")
-                                ->debug("Returning UChar_t quantity as int: {}",
+                                ->debug("Returning UChar_t/Short_t quantity as int: {}",
                                         cast_result);
                             return cast_result;
                         } else {

--- a/include/reweighting.hxx
+++ b/include/reweighting.hxx
@@ -28,9 +28,9 @@ ROOT::RDF::RNode LHEalphaS(ROOT::RDF::RNode df,
                         const std::string &variation);
 ROOT::RDF::RNode TopPt(ROOT::RDF::RNode df,
                         const std::string &outputname,
-                        const std::string &gen_pdg_id,
-                        const std::string &gen_status,
-                        const std::string &gen_pt);
+                        const std::string &genparticles_pdg_id,
+                        const std::string &genparticles_status_flags,
+                        const std::string &genparticles_pt);
 ROOT::RDF::RNode ZPtMass(ROOT::RDF::RNode df,
                             const std::string &outputname,
                             const std::string &gen_boson,

--- a/include/taus.hxx
+++ b/include/taus.hxx
@@ -36,7 +36,10 @@ ROOT::RDF::RNode PtCorrectionMC_genuineTau(
     const std::string &variation_dm10, const std::string &variation_dm11);
 
 namespace quantity {
-ROOT::RDF::RNode IDFlag(ROOT::RDF::RNode df, const std::string &outputname,
+ROOT::RDF::RNode IDFlag_v9(ROOT::RDF::RNode df, const std::string &outputname,
+                        const std::string &ID, const std::string &index_vector,
+                        const int &position, const int &wp);
+ROOT::RDF::RNode IDFlag_v12(ROOT::RDF::RNode df, const std::string &outputname,
                         const std::string &ID, const std::string &index_vector,
                         const int &position, const int &wp);
 } // end namespace quantity

--- a/include/utility/utility.hxx
+++ b/include/utility/utility.hxx
@@ -38,8 +38,9 @@ inline std::pair<ROOT::RDF::RNode, std::string> Cast(ROOT::RDF::RNode df,
                             const std::string &column) {
     auto new_df = df;
     auto new_col = column;
+    auto inputtype = df.GetColumnType(column);
     
-    if (df.GetColumnType(column) != std::string(outputtype)) {
+    if (inputtype != outputtype) {
         new_col = outputname;
         auto cols = df.GetColumnNames();
         // check if the column is already defined, this is relevant for systematic
@@ -47,12 +48,16 @@ inline std::pair<ROOT::RDF::RNode, std::string> Cast(ROOT::RDF::RNode df,
         if (std::find(cols.begin(), cols.end(), outputname) == cols.end()) {
             new_df = df.Define(
                 outputname,
-                [] (const I& column) {
-                    return static_cast<O>(column);
+                [] (const I& values) {
+                    return static_cast<O>(values);
                 },
                 {column});
         }
     }
+    Logger::get("utility::Cast")
+        ->debug("Casting type {} to type {} "
+                "for column {} to {}",
+                inputtype, outputtype, column, new_col);
 
     return {new_df, new_col};
 }

--- a/include/utility/utility.hxx
+++ b/include/utility/utility.hxx
@@ -15,11 +15,55 @@
 namespace utility {
 
 /**
+ * @brief This function takes a column and casts it from type `I` to 
+ * another type `O`. 
+ *
+ * @note This functionality is mainly used to mitigate type changes 
+ * between nanoAOD versions.
+ *
+ * @tparam O type of the output column
+ * @tparam I type of the input column
+ * @param outputname name of the output column containing the recasted 
+ * column
+ * @param outputtype string with the type of the output column 
+ * @param column name of the column that should be recasted to another 
+ * type
+ *
+ * @return a new dataframe with the new column
+ */
+template<typename O, typename I>
+inline std::pair<ROOT::RDF::RNode, std::string> Cast(ROOT::RDF::RNode df,
+                            const std::string &outputname,
+                            const std::string &outputtype,
+                            const std::string &column) {
+    auto new_df = df;
+    auto new_col = column;
+    
+    if (df.GetColumnType(column) != std::string(outputtype)) {
+        new_col = outputname;
+        auto cols = df.GetColumnNames();
+        // check if the column is already defined, this is relevant for systematic
+        // variations were this Define would be done multiple times
+        if (std::find(cols.begin(), cols.end(), outputname) == cols.end()) {
+            new_df = df.Define(
+                outputname,
+                [] (const I& column) {
+                    return static_cast<O>(column);
+                },
+                {column});
+        }
+    }
+
+    return {new_df, new_col};
+}
+
+/**
  * @brief Function to check if two double values are approximately equal
  *
  * @param value1 first double value to compare
  * @param value2 second double value to compare
  * @param maxDelta maximum difference between the two values
+ *
  * @return true or false
  */
 inline bool ApproxEqual(double value1, double value2, double maxDelta = 1e-5) {

--- a/src/embedding.cxx
+++ b/src/embedding.cxx
@@ -384,8 +384,8 @@ PtCorrection_byValue(ROOT::RDF::RNode df, const std::string &outputname,
 
     auto correction_lambda = [sf_dm0, sf_dm1, sf_dm10,
                               sf_dm11](const ROOT::RVec<float> &pts,
-                                       const ROOT::RVec<int> &decay_modes_v12) {
-        auto decay_modes = static_cast<ROOT::RVec<UChar_t>>(decay_modes_v12);
+                                       const ROOT::RVec<UChar_t> &decay_modes_v12) {
+        auto decay_modes = static_cast<ROOT::RVec<int>>(decay_modes_v12);
         ROOT::RVec<float> corrected_pts(pts.size());
         for (int i = 0; i < pts.size(); i++) {
             if (decay_modes.at(i) == 0)

--- a/src/embedding.cxx
+++ b/src/embedding.cxx
@@ -380,7 +380,7 @@ PtCorrection_byValue(ROOT::RDF::RNode df, const std::string &outputname,
     // In nanoAODv12 the type of tau decay mode was changed to UChar_t
     // For v9 compatibility a type casting is applied
     auto [df1, decay_mode_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
-            df, decay_mode+"_v12", "ROOT::RVec<UChar_t>", decay_mode);
+            df, decay_mode+"_v12", "ROOT::VecOps::RVec<UChar_t>", decay_mode);
 
     auto correction_lambda = [sf_dm0, sf_dm1, sf_dm10,
                               sf_dm11](const ROOT::RVec<float> &pts,

--- a/src/genparticles.cxx
+++ b/src/genparticles.cxx
@@ -57,9 +57,9 @@ ROOT::RDF::RNode HadronicGenTaus(ROOT::RDF::RNode df,
     // In nanoAODv12 the type of genparticle status flags / mother index were changed to UShort_t / Short_t
     // For v9 compatibility a type casting is applied
     auto [df1, genparticles_status_flags_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, genparticles_status_flags+"_v12", "ROOT::RVec<UShort_t>", genparticles_status_flags);
+            df, genparticles_status_flags+"_v12", "ROOT::VecOps::RVec<UShort_t>", genparticles_status_flags);
     auto [df2, genparticles_mother_index_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
-            df1, genparticles_mother_index+"_v12", "ROOT::RVec<Short_t>", genparticles_mother_index);
+            df1, genparticles_mother_index+"_v12", "ROOT::VecOps::RVec<Short_t>", genparticles_mother_index);
 
     auto gentaus = [](const ROOT::RVec<int> &pdg_ids,
                       const ROOT::RVec<UShort_t> &status_flags_v12,
@@ -220,7 +220,7 @@ ROOT::RDF::RNode GenMatching(
     // In nanoAODv12 the type of genparticle status flags was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, genparticles_status_flags_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, genparticles_status_flags+"_v12", "ROOT::RVec<UShort_t>", genparticles_status_flags);
+            df, genparticles_status_flags+"_v12", "ROOT::VecOps::RVec<UShort_t>", genparticles_status_flags);
 
     auto match_tau = [](const std::vector<int> &had_gen_taus,
                            const ROOT::RVec<int> &pdg_ids,
@@ -409,9 +409,9 @@ ROOT::RDF::RNode GenMatching(
     // In nanoAODv12 the type of genparticle status flags / mother index were changed to UShort_t / Short_t
     // For v9 compatibility a type casting is applied
     auto [df1, genparticles_status_flags_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, genparticles_status_flags+"_v12", "ROOT::RVec<UShort_t>", genparticles_status_flags);
+            df, genparticles_status_flags+"_v12", "ROOT::VecOps::RVec<UShort_t>", genparticles_status_flags);
     auto [df2, genparticles_mother_index_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
-            df1, genparticles_mother_index+"_v12", "ROOT::RVec<Short_t>", genparticles_mother_index);
+            df1, genparticles_mother_index+"_v12", "ROOT::VecOps::RVec<Short_t>", genparticles_mother_index);
 
     auto match_tau = [](const std::vector<int> &had_gen_taus,
                            const ROOT::RVec<int> &pdg_ids,

--- a/src/jets.cxx
+++ b/src/jets.cxx
@@ -89,7 +89,7 @@ PtCorrectionMC(ROOT::RDF::RNode df,
     // In nanoAODv12 the type of jet/fatjet ID was changed to UChar_t
     // For v9 compatibility a type casting is applied
     auto [df1, jet_id_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
-            df, jet_id+"_v12", "ROOT::RVec<UChar_t>", jet_id);
+            df, jet_id+"_v12", "ROOT::VecOps::RVec<UChar_t>", jet_id);
 
     // identifying jet radius from algorithm
     float jet_radius = 0.4;
@@ -386,7 +386,7 @@ ROOT::RDF::RNode CutPileupID(ROOT::RDF::RNode df, const std::string &outputname,
     // In nanoAODv12 the type of jet PU ID was changed to UChar_t
     // For v9 compatibility a type casting is applied
     auto [df1, jet_pu_id_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
-            df, jet_pu_id+"_v12", "ROOT::RVec<UChar_t>", jet_pu_id);
+            df, jet_pu_id+"_v12", "ROOT::VecOps::RVec<UChar_t>", jet_pu_id);
 
     auto pass_pu_id = [pu_id_cut, pt_cut](const ROOT::RVec<UChar_t> &pu_ids_v12,
                                           const ROOT::RVec<float> &jet_pts) {
@@ -687,7 +687,7 @@ Btagging(ROOT::RDF::RNode df,
     // In nanoAODv12 the type of jet flavor was changed to UChar_t
     // For v9 compatibility a type casting is applied
     auto [df1, flavor_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
-            df, flavor+"_v12", "ROOT::RVec<UChar_t>", flavor);
+            df, flavor+"_v12", "ROOT::VecOps::RVec<UChar_t>", flavor);
 
     auto btagSF_lambda = [evaluator,
                           variation](const ROOT::RVec<float> &pts,

--- a/src/jets.cxx
+++ b/src/jets.cxx
@@ -394,7 +394,7 @@ ROOT::RDF::RNode CutPileupID(ROOT::RDF::RNode df, const std::string &outputname,
         ROOT::RVec<int> mask = (id_mask + pt_mask) > 0;
         return mask;
     };
-    auto df1 = df.Define(outputname, pass_pu_id, {jet_pu_id_int, jet_pt});
+    auto df1 = df_int.Define(outputname, pass_pu_id, {jet_pu_id_int, jet_pt});
     return df1;
 }
 

--- a/src/jets.cxx
+++ b/src/jets.cxx
@@ -4,6 +4,7 @@
 #include "../include/defaults.hxx"
 #include "../include/utility/CorrectionManager.hxx"
 #include "../include/utility/Logger.hxx"
+#include "../include/utility/utility.hxx"
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RVec.hxx"
 #include "TRandom3.h"
@@ -85,6 +86,11 @@ PtCorrectionMC(ROOT::RDF::RNode df,
                const std::string &jer_tag, bool reapply_jes,
                const int &jes_shift, const std::string &jer_shift,
                const int jer_seed) {
+    // In nanoAODv12 the type of jet/fatjet ID was changed to UChar_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, jet_id_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
+            df, jet_id+"_v12", "ROOT::RVec<UChar_t>", jet_id);
+
     // identifying jet radius from algorithm
     float jet_radius = 0.4;
     if (jec_algo.find("AK8") != std::string::npos) {
@@ -133,14 +139,15 @@ PtCorrectionMC(ROOT::RDF::RNode df,
                                           const ROOT::RVec<float> &phis,
                                           const ROOT::RVec<float> &area,
                                           const ROOT::RVec<float> &raw_factors,
-                                          const ROOT::RVec<int> &ids,
+                                          const ROOT::RVec<UChar_t> &ids_v12,
                                           const ROOT::RVec<float> &gen_pts,
                                           const ROOT::RVec<float> &gen_etas,
                                           const ROOT::RVec<float> &gen_phis,
                                           const float &rho) {
         // random value generator for jet smearing
         TRandom3 randm = TRandom3(jer_seed);
-
+        
+        auto ids = static_cast<ROOT::RVec<int>>(ids_v12);
         ROOT::RVec<float> corrected_pts;
         for (int i = 0; i < pts.size(); i++) {
             float corr_pt = pts.at(i);
@@ -254,10 +261,10 @@ PtCorrectionMC(ROOT::RDF::RNode df,
         }
         return corrected_pts;
     };
-    auto df1 = df.Define(outputname, correction_lambda,
+    auto df2 = df1.Define(outputname, correction_lambda,
                          {jet_pt, jet_eta, jet_phi, jet_area, jet_raw_factor,
-                          jet_id, gen_jet_pt, gen_jet_eta, gen_jet_phi, rho});
-    return df1;
+                          jet_id_column, gen_jet_pt, gen_jet_eta, gen_jet_phi, rho});
+    return df2;
 }
 
 /**
@@ -377,25 +384,20 @@ ROOT::RDF::RNode CutPileupID(ROOT::RDF::RNode df, const std::string &outputname,
                              const std::string &jet_pt, const int &pu_id_cut,
                              const float &pt_cut) {
     // In nanoAODv12 the type of jet PU ID was changed to UChar_t
-    auto jet_pu_id_int = jet_pu_id;
-    auto df_int = df;
-    // Recasting to int if it is UChar_t
-    if (df.GetColumnType(jet_pu_id) == "ROOT::VecOps::RVec<UChar_t>") {
-        jet_pu_id_int = jet_pu_id + "_int";
-        df_int = df_int.Define(jet_pu_id_int, [](const ROOT::RVec<UChar_t>& v) {
-            return ROOT::RVec<int>(v.begin(), v.end());
-        }, {jet_pu_id});
-    }
+    // For v9 compatibility a type casting is applied
+    auto [df1, jet_pu_id_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
+            df, jet_pu_id+"_v12", "ROOT::RVec<UChar_t>", jet_pu_id);
 
-    auto pass_pu_id = [pu_id_cut, pt_cut](const ROOT::RVec<int> &pu_ids,
+    auto pass_pu_id = [pu_id_cut, pt_cut](const ROOT::RVec<UChar_t> &pu_ids_v12,
                                           const ROOT::RVec<float> &jet_pts) {
+        auto pu_ids = static_cast<ROOT::RVec<int>>(pu_ids_v12);
         ROOT::RVec<int> id_mask = pu_ids >= pu_id_cut;
         ROOT::RVec<int> pt_mask = jet_pts >= pt_cut;
         ROOT::RVec<int> mask = (id_mask + pt_mask) > 0;
         return mask;
     };
-    auto df1 = df_int.Define(outputname, pass_pu_id, {jet_pu_id_int, jet_pt});
-    return df1;
+    auto df2 = df1.Define(outputname, pass_pu_id, {jet_pu_id_column, jet_pt});
+    return df2;
 }
 
 /**
@@ -681,26 +683,21 @@ Btagging(ROOT::RDF::RNode df,
     Logger::get("physicsobject::jet::scalefactor::Btagging")->debug("Correction algorithm - Name {}",
                                  sf_name);
     auto evaluator = correction_manager.loadCorrection(sf_file, sf_name);
-
+    
     // In nanoAODv12 the type of jet flavor was changed to UChar_t
-    auto flavor_int = flavor;
-    auto df_int = df;
-    // Recasting to int if it is UChar_t
-    if (df.GetColumnType(flavor) == "ROOT::VecOps::RVec<UChar_t>") {
-        flavor_int = flavor + "_int";
-        df_int = df_int.Define(flavor_int, [](const ROOT::RVec<UChar_t>& v) {
-            return ROOT::RVec<int>(v.begin(), v.end());
-        }, {flavor});
-    }
+    // For v9 compatibility a type casting is applied
+    auto [df1, flavor_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
+            df, flavor+"_v12", "ROOT::RVec<UChar_t>", flavor);
 
     auto btagSF_lambda = [evaluator,
                           variation](const ROOT::RVec<float> &pts,
                                      const ROOT::RVec<float> &etas,
                                      const ROOT::RVec<float> &btag_values,
-                                     const ROOT::RVec<int> &flavors,
+                                     const ROOT::RVec<UChar_t> &flavors_v12,
                                      const ROOT::RVec<int> &jet_mask,
                                      const ROOT::RVec<int> &bjet_mask,
                                      const ROOT::RVec<int> &jet_veto_mask) {
+        auto flavors = static_cast<ROOT::RVec<int>>(flavors_v12);
         Logger::get("physicsobject::jet::scalefactor::Btagging")->debug("Vatiation - Name {}", variation);
         float sf = 1.;
         for (int i = 0; i < pts.size(); i++) {
@@ -759,10 +756,10 @@ Btagging(ROOT::RDF::RNode df,
         Logger::get("physicsobject::jet::scalefactor::Btagging")->debug("Event Scale Factor {}", sf);
         return sf;
     };
-    auto df1 = df_int.Define(
+    auto df2 = df1.Define(
         outputname, btagSF_lambda,
-        {pt, eta, btag_value, flavor_int, jet_mask, bjet_mask, jet_veto_mask});
-    return df1;
+        {pt, eta, btag_value, flavor_column, jet_mask, bjet_mask, jet_veto_mask});
+    return df2;
 }
 } // end namespace scalefactor
 } // end namespace jet

--- a/src/met.cxx
+++ b/src/met.cxx
@@ -64,10 +64,6 @@ ROOT::RDF::RNode calculateGenBosonVector(
     const std::string &genparticle_status,
     const std::string &genparticle_statusflag, const std::string outputname,
     bool is_data) {
-    // In nanoAODv12 the type of genparticle status flags was changed to UShort_t
-    // For v9 compatibility a type casting is applied
-    auto [df1, genparticle_statusflag_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, genparticle_statusflag+"_v12", "ROOT::VecOps::RVec<UShort_t>", genparticle_statusflag);
     auto calculateGenBosonVector =
         [](const ROOT::RVec<float> &genparticle_pt,
            const ROOT::RVec<float> &genparticle_eta,
@@ -116,12 +112,16 @@ ROOT::RDF::RNode calculateGenBosonVector(
             return metpair;
         };
     if (!is_data) {
+        // In nanoAODv12 the type of genparticle status flags was changed to UShort_t
+        // For v9 compatibility a type casting is applied
+        auto [df1, genparticle_statusflag_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+                df, genparticle_statusflag+"_v12", "ROOT::VecOps::RVec<UShort_t>", genparticle_statusflag);
         return df1.Define(outputname, calculateGenBosonVector,
                          {genparticle_pt, genparticle_eta, genparticle_phi,
                           genparticle_mass, genparticle_id, genparticle_status,
                           genparticle_statusflag_column});
     } else {
-        return df1.Define(outputname, []() {
+        return df.Define(outputname, []() {
             std::pair<ROOT::Math::PtEtaPhiMVector, ROOT::Math::PtEtaPhiMVector>
                 metpair = {default_lorentzvector, default_lorentzvector};
             return metpair;

--- a/src/met.cxx
+++ b/src/met.cxx
@@ -67,7 +67,7 @@ ROOT::RDF::RNode calculateGenBosonVector(
     // In nanoAODv12 the type of genparticle status flags was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, genparticle_statusflag_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, genparticle_statusflag+"_v12", "ROOT::RVec<UShort_t>", genparticle_statusflag);
+            df, genparticle_statusflag+"_v12", "ROOT::VecOps::RVec<UShort_t>", genparticle_statusflag);
     auto calculateGenBosonVector =
         [](const ROOT::RVec<float> &genparticle_pt,
            const ROOT::RVec<float> &genparticle_eta,

--- a/src/met.cxx
+++ b/src/met.cxx
@@ -64,6 +64,10 @@ ROOT::RDF::RNode calculateGenBosonVector(
     const std::string &genparticle_status,
     const std::string &genparticle_statusflag, const std::string outputname,
     bool is_data) {
+    // In nanoAODv12 the type of genparticle status flags was changed to UShort_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, genparticle_statusflag_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, genparticle_statusflag+"_v12", "ROOT::RVec<UShort_t>", genparticle_statusflag);
     auto calculateGenBosonVector =
         [](const ROOT::RVec<float> &genparticle_pt,
            const ROOT::RVec<float> &genparticle_eta,
@@ -71,7 +75,8 @@ ROOT::RDF::RNode calculateGenBosonVector(
            const ROOT::RVec<float> &genparticle_mass,
            const ROOT::RVec<int> &genparticle_id,
            const ROOT::RVec<int> &genparticle_status,
-           const ROOT::RVec<int> &genparticle_statusflag) {
+           const ROOT::RVec<UShort_t> &genparticle_statusflag_v12) {
+            auto genparticle_statusflag = static_cast<ROOT::RVec<int>>(genparticle_statusflag_v12);
             ROOT::Math::PtEtaPhiMVector genBoson;
             ROOT::Math::PtEtaPhiMVector visgenBoson;
             ROOT::Math::PtEtaPhiMVector genparticle;
@@ -111,12 +116,12 @@ ROOT::RDF::RNode calculateGenBosonVector(
             return metpair;
         };
     if (!is_data) {
-        return df.Define(outputname, calculateGenBosonVector,
+        return df1.Define(outputname, calculateGenBosonVector,
                          {genparticle_pt, genparticle_eta, genparticle_phi,
                           genparticle_mass, genparticle_id, genparticle_status,
-                          genparticle_statusflag});
+                          genparticle_statusflag_column});
     } else {
-        return df.Define(outputname, []() {
+        return df1.Define(outputname, []() {
             std::pair<ROOT::Math::PtEtaPhiMVector, ROOT::Math::PtEtaPhiMVector>
                 metpair = {default_lorentzvector, default_lorentzvector};
             return metpair;

--- a/src/pairselection.cxx
+++ b/src/pairselection.cxx
@@ -125,13 +125,21 @@ buildtruegenpair(ROOT::RDF::RNode df, const std::string &statusflags,
                  const std::string &motherids, const std::string &pts,
                  const std::string &genpair, const int mother_pdgid,
                  const int daughter_1_pdgid, const int daughter_2_pdgid) {
+    // In nanoAODv12 the type of genparticle status flags / mother index were changed to UShort_t / Short_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, statusflags_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, statusflags+"_v12", "ROOT::RVec<UShort_t>", statusflags);
+    auto [df2, motherids_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
+            df1, motherids+"_v12", "ROOT::RVec<Short_t>", motherids);
 
     auto getTrueGenPair = [mother_pdgid, daughter_1_pdgid,
-                           daughter_2_pdgid](const ROOT::RVec<int> &statusflags,
+                           daughter_2_pdgid](const ROOT::RVec<UShort_t> &statusflags_v12,
                                              const ROOT::RVec<int> &status,
                                              const ROOT::RVec<int> &pdgids,
-                                             const ROOT::RVec<int> &motherids,
+                                             const ROOT::RVec<Short_t> &motherids_v12,
                                              const ROOT::RVec<float> &pts) {
+        auto statusflags = static_cast<ROOT::RVec<int>>(statusflags_v12);
+        auto motherids = static_cast<ROOT::RVec<int>>(motherids_v12);
         ROOT::RVec<int> genpair = {-1, -1};
 
         // first we build structs, one for each genparticle
@@ -237,8 +245,8 @@ buildtruegenpair(ROOT::RDF::RNode df, const std::string &statusflags,
 
         return genpair;
     };
-    return df.Define(genpair, getTrueGenPair,
-                     {statusflags, status, pdgids, motherids, pts});
+    return df2.Define(genpair, getTrueGenPair,
+                     {statusflags_column, status, pdgids, motherids_column, pts});
 }
 /// This function flags events, where a suitable particle pair is found.
 /// A pair is considered suitable, if a PairSelectionAlgo (like

--- a/src/pairselection.cxx
+++ b/src/pairselection.cxx
@@ -70,9 +70,18 @@ ROOT::RDF::RNode buildgenpair(ROOT::RDF::RNode df, const std::string &recopair,
                               const std::string &genindex_particle1,
                               const std::string &genindex_particle2,
                               const std::string &genpairname) {
+    // In nanoAODv12 the types of gen object indices were changed to Short_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, genindex_particle1_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
+            df, genindex_particle1+"_v12", "ROOT::RVec<Short_t>", genindex_particle1);
+    auto [df2, genindex_particle2_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
+            df1, genindex_particle2+"_v12", "ROOT::RVec<Short_t>", genindex_particle2);
+
     auto getGenPair = [](const ROOT::RVec<int> &recopair,
-                         const ROOT::RVec<int> &genindex_particle1,
-                         const ROOT::RVec<int> &genindex_particle2) {
+                         const ROOT::RVec<Short_t> &genindex_particle1_v12,
+                         const ROOT::RVec<Short_t> &genindex_particle2_v12) {
+        auto genindex_particle1 = static_cast<ROOT::RVec<int>>(genindex_particle1_v12);
+        auto genindex_particle2 = static_cast<ROOT::RVec<int>>(genindex_particle2_v12);
         ROOT::RVec<int> genpair = {-1, -1};
         Logger::get("buildgenpair")->debug("existing DiTauPair: {}", recopair);
         genpair[0] = genindex_particle1.at(recopair.at(0), -1);
@@ -81,8 +90,8 @@ ROOT::RDF::RNode buildgenpair(ROOT::RDF::RNode df, const std::string &recopair,
             ->debug("matching GenDiTauPair: {}", genpair);
         return genpair;
     };
-    return df.Define(genpairname, getGenPair,
-                     {recopair, genindex_particle1, genindex_particle2});
+    return df2.Define(genpairname, getGenPair,
+                     {recopair, genindex_particle1_column, genindex_particle2_column});
 }
 
 /**

--- a/src/pairselection.cxx
+++ b/src/pairselection.cxx
@@ -73,9 +73,9 @@ ROOT::RDF::RNode buildgenpair(ROOT::RDF::RNode df, const std::string &recopair,
     // In nanoAODv12 the types of gen object indices were changed to Short_t
     // For v9 compatibility a type casting is applied
     auto [df1, genindex_particle1_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
-            df, genindex_particle1+"_v12", "ROOT::RVec<Short_t>", genindex_particle1);
+            df, genindex_particle1+"_v12", "ROOT::VecOps::RVec<Short_t>", genindex_particle1);
     auto [df2, genindex_particle2_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
-            df1, genindex_particle2+"_v12", "ROOT::RVec<Short_t>", genindex_particle2);
+            df1, genindex_particle2+"_v12", "ROOT::VecOps::RVec<Short_t>", genindex_particle2);
 
     auto getGenPair = [](const ROOT::RVec<int> &recopair,
                          const ROOT::RVec<Short_t> &genindex_particle1_v12,
@@ -128,9 +128,9 @@ buildtruegenpair(ROOT::RDF::RNode df, const std::string &statusflags,
     // In nanoAODv12 the type of genparticle status flags / mother index were changed to UShort_t / Short_t
     // For v9 compatibility a type casting is applied
     auto [df1, statusflags_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, statusflags+"_v12", "ROOT::RVec<UShort_t>", statusflags);
+            df, statusflags+"_v12", "ROOT::VecOps::RVec<UShort_t>", statusflags);
     auto [df2, motherids_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
-            df1, motherids+"_v12", "ROOT::RVec<Short_t>", motherids);
+            df1, motherids+"_v12", "ROOT::VecOps::RVec<Short_t>", motherids);
 
     auto getTrueGenPair = [mother_pdgid, daughter_1_pdgid,
                            daughter_2_pdgid](const ROOT::RVec<UShort_t> &statusflags_v12,

--- a/src/quantities.cxx
+++ b/src/quantities.cxx
@@ -406,7 +406,7 @@ ROOT::RDF::RNode JetMatching(ROOT::RDF::RNode df,
     // In nanoAODv12 the type ofs object to jet indices were changed to Short_t
     // For v9 compatibility a type casting is applied
     auto [df1, object_jet_index_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
-            df, object_jet_index+"_v12", "ROOT::RVec<Short_t>", object_jet_index);
+            df, object_jet_index+"_v12", "ROOT::VecOps::RVec<Short_t>", object_jet_index);
     return df1.Define(outputname,
                      [position](const ROOT::RVec<float> &quantity,
                                 const ROOT::RVec<Short_t> &obj_jet_idx_v12,
@@ -448,9 +448,9 @@ ROOT::RDF::RNode GenJetMatching(ROOT::RDF::RNode df,
     // In nanoAODv12 the types of jet indices were changed to Short_t
     // For v9 compatibility a type casting is applied
     auto [df1, jet_genjet_index_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
-            df, jet_genjet_index+"_v12", "ROOT::RVec<Short_t>", jet_genjet_index);
+            df, jet_genjet_index+"_v12", "ROOT::VecOps::RVec<Short_t>", jet_genjet_index);
     auto [df2, object_jet_index_column] = utility::Cast<ROOT::RVec<Short_t>, ROOT::RVec<Int_t>>(
-            df1, object_jet_index+"_v12", "ROOT::RVec<Short_t>", object_jet_index);
+            df1, object_jet_index+"_v12", "ROOT::VecOps::RVec<Short_t>", object_jet_index);
     return df2.Define(outputname,
                      [position](const ROOT::RVec<float> &quantity,
                                 const ROOT::RVec<Short_t> &jet_genjet_idx_v12,

--- a/src/reweighting.cxx
+++ b/src/reweighting.cxx
@@ -350,11 +350,11 @@ ROOT::RDF::RNode LHEalphaS(ROOT::RDF::RNode df,
  *
  * @param df input dataframe
  * @param outputname name of the output column containing the derived event weight
- * @param gen_pdg_id name of the column containing the PDG IDs of the generator
+ * @param genparticles_pdg_id name of the column containing the PDG IDs of the generator
  * particles
- * @param gen_status name of the column containing the status flags of the
+ * @param genparticles_status_flags name of the column containing the status flags of the
  * generator particles, where bit 13 contains the isLastCopy flag
- * @param gen_pt name of the column containing the pt of the generator particles
+ * @param genparticles_pt name of the column containing the pt of the generator particles
  *
  * @return a new dataframe containing the new column
  *
@@ -363,16 +363,21 @@ ROOT::RDF::RNode LHEalphaS(ROOT::RDF::RNode df,
  */
 ROOT::RDF::RNode TopPt(ROOT::RDF::RNode df,
                         const std::string &outputname,
-                        const std::string &gen_pdg_id,
-                        const std::string &gen_status,
-                        const std::string &gen_pt) {
+                        const std::string &genparticles_pdg_id,
+                        const std::string &genparticles_status_flags,
+                        const std::string &genparticles_pt) {
+    // In nanoAODv12 the type of genparticle status flags was changed to UShort_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, genparticles_status_flags_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, genparticles_status_flags+"_v12", "ROOT::RVec<UShort_t>", genparticles_status_flags);
 
     auto ttbarreweightlambda = [](const ROOT::RVec<int> pdg_ids,
-                                  const ROOT::RVec<int> status,
+                                  const ROOT::RVec<UShort_t> status_flags_v12,
                                   const ROOT::RVec<float> pts) {
+        auto status_flags = static_cast<ROOT::RVec<int>>(status_flags_v12);
         std::vector<float> top_pts;
         for (size_t i = 0; i < pdg_ids.size(); i++) {
-            if (std::abs(pdg_ids[i]) == 6 && ((status[i] >> 13) & 1) == 1)
+            if (std::abs(pdg_ids[i]) == 6 && ((status_flags[i] >> 13) & 1) == 1)
                 top_pts.push_back(pts[i]);
         }
         if (top_pts.size() != 2) {
@@ -394,9 +399,9 @@ ROOT::RDF::RNode TopPt(ROOT::RDF::RNode df,
         return sqrt(exp(parameter_a + parameter_b * top_pts[0]) *
                     exp(parameter_a + parameter_b * top_pts[1]));
     };
-    auto df1 = df.Define(outputname, ttbarreweightlambda,
-                         {gen_pdg_id, gen_status, gen_pt});
-    return df1;
+    auto df2 = df1.Define(outputname, ttbarreweightlambda,
+                {genparticles_pdg_id, genparticles_status_flags_column, genparticles_pt});
+    return df2;
 }
 
 /**

--- a/src/reweighting.cxx
+++ b/src/reweighting.cxx
@@ -369,7 +369,7 @@ ROOT::RDF::RNode TopPt(ROOT::RDF::RNode df,
     // In nanoAODv12 the type of genparticle status flags was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, genparticles_status_flags_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, genparticles_status_flags+"_v12", "ROOT::RVec<UShort_t>", genparticles_status_flags);
+            df, genparticles_status_flags+"_v12", "ROOT::VecOps::RVec<UShort_t>", genparticles_status_flags);
 
     auto ttbarreweightlambda = [](const ROOT::RVec<int> pdg_ids,
                                   const ROOT::RVec<UShort_t> status_flags_v12,

--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -81,7 +81,7 @@ PtCorrectionMC_eleFake(ROOT::RDF::RNode df,
     // In nanoAODv12 the type of tau decay mode was changed to UChar_t
     // For v9 compatibility a type casting is applied
     auto [df1, decay_mode_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
-            df, decay_mode+"_v12", "ROOT::RVec<UChar_t>", decay_mode);
+            df, decay_mode+"_v12", "ROOT::VecOps::RVec<UChar_t>", decay_mode);
 
     auto evaluator =
         correction_manager.loadCorrection(es_file, correction_name);
@@ -204,7 +204,7 @@ PtCorrectionMC_muFake(ROOT::RDF::RNode df,
     // In nanoAODv12 the type of tau decay mode was changed to UChar_t
     // For v9 compatibility a type casting is applied
     auto [df1, decay_mode_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
-            df, decay_mode+"_v12", "ROOT::RVec<UChar_t>", decay_mode);
+            df, decay_mode+"_v12", "ROOT::VecOps::RVec<UChar_t>", decay_mode);
 
     auto evaluator =
         correction_manager.loadCorrection(es_file, correction_name);
@@ -300,7 +300,7 @@ ROOT::RDF::RNode PtCorrectionMC_genuineTau(
     // In nanoAODv12 the type of tau decay mode was changed to UChar_t
     // For v9 compatibility a type casting is applied
     auto [df1, decay_mode_column] = utility::Cast<ROOT::RVec<UChar_t>, ROOT::RVec<Int_t>>(
-            df, decay_mode+"_v12", "ROOT::RVec<UChar_t>", decay_mode);
+            df, decay_mode+"_v12", "ROOT::VecOps::RVec<UChar_t>", decay_mode);
 
     auto evaluator =
         correction_manager.loadCorrection(es_file, correction_name);

--- a/src/triggers.cxx
+++ b/src/triggers.cxx
@@ -232,7 +232,7 @@ ROOT::RDF::RNode GenerateSingleTriggerFlag(
     // In nanoAODv12 the type of trigger object ID was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
+            df, triggerobject_id+"_v12", "ROOT::VecOps::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, pt_cut, eta_cut,
                          trigger_particle_id_cut, triggerbit_cut, hltpath](
@@ -369,7 +369,7 @@ ROOT::RDF::RNode GenerateDoubleTriggerFlag(
     // In nanoAODv12 the type of trigger object ID was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
+            df, triggerobject_id+"_v12", "ROOT::VecOps::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, p1_pt_cut, p2_pt_cut, p1_eta_cut,
                          p2_eta_cut, p1_trigger_particle_id_cut,
@@ -515,7 +515,7 @@ ROOT::RDF::RNode MatchDoubleTriggerObject(
     // In nanoAODv12 the type of trigger object ID was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
+            df, triggerobject_id+"_v12", "ROOT::VecOps::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch =
         [DeltaR_threshold, p1_pt_cut, p2_pt_cut, p1_eta_cut, p2_eta_cut,
@@ -599,7 +599,7 @@ ROOT::RDF::RNode MatchSingleTriggerObject(
     // In nanoAODv12 the type of trigger object ID was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
+            df, triggerobject_id+"_v12", "ROOT::VecOps::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, pt_cut, eta_cut,
                          trigger_particle_id_cut, triggerbit_cut](
@@ -784,7 +784,7 @@ ROOT::RDF::RNode MatchSingleTriggerObject(
     // In nanoAODv12 the type of trigger object ID was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
+            df, triggerobject_id+"_v12", "ROOT::VecOps::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, pt_cut, eta_cut,
                          trigger_particle_id_cut, triggerbit_cut,
@@ -858,7 +858,7 @@ ROOT::RDF::RNode GenerateSingleTriggerFlag(
     // In nanoAODv12 the type of trigger object ID was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
+            df, triggerobject_id+"_v12", "ROOT::VecOps::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch =
         [DeltaR_threshold, pt_cut, eta_cut, trigger_particle_id_cut,
@@ -1000,7 +1000,7 @@ ROOT::RDF::RNode GenerateDoubleTriggerFlag(
     // In nanoAODv12 the type of trigger object ID was changed to UShort_t
     // For v9 compatibility a type casting is applied
     auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
-            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
+            df, triggerobject_id+"_v12", "ROOT::VecOps::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, p1_pt_cut, p2_pt_cut, p1_eta_cut,
                          p2_eta_cut, p1_trigger_particle_id_cut,

--- a/src/triggers.cxx
+++ b/src/triggers.cxx
@@ -3,6 +3,7 @@
 
 #include "../include/utility/CorrectionManager.hxx"
 #include "../include/utility/Logger.hxx"
+#include "../include/utility/utility.hxx"
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RVec.hxx"
 #include "bitset"
@@ -228,16 +229,21 @@ ROOT::RDF::RNode GenerateSingleTriggerFlag(
     const std::string &hltpath, const float &pt_cut, const float &eta_cut,
     const int &trigger_particle_id_cut, const int &triggerbit_cut,
     const float &DeltaR_threshold) {
+    // In nanoAODv12 the type of trigger object ID was changed to UShort_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, pt_cut, eta_cut,
                          trigger_particle_id_cut, triggerbit_cut, hltpath](
                             bool hltpath_match,
                             const ROOT::Math::PtEtaPhiMVector &particle_p4,
                             ROOT::RVec<int> triggerobject_bits,
-                            ROOT::RVec<int> triggerobject_ids,
+                            ROOT::RVec<UShort_t> triggerobject_ids_v12,
                             ROOT::RVec<float> triggerobject_pts,
                             ROOT::RVec<float> triggerobject_etas,
                             ROOT::RVec<float> triggerobject_phis) {
+        auto triggerobject_ids = static_cast<ROOT::RVec<int>>(triggerobject_ids_v12);
         Logger::get("GenerateSingleTriggerFlag")->debug("Checking Trigger");
         Logger::get("CheckTriggerMatch")
             ->debug("Selected trigger: {}", hltpath);
@@ -290,12 +296,12 @@ ROOT::RDF::RNode GenerateSingleTriggerFlag(
     } else {
         Logger::get("GenerateSingleTriggerFlag")
             ->debug("Found matching trigger: {}", matched_trigger_names[0]);
-        auto df1 =
-            df.Define(triggerflag_name, triggermatch,
+        auto df2 =
+            df1.Define(triggerflag_name, triggermatch,
                       {matched_trigger_names[0], particle_p4,
-                       triggerobject_bits, triggerobject_id, triggerobject_pt,
+                       triggerobject_bits, triggerobject_id_column, triggerobject_pt,
                        triggerobject_eta, triggerobject_phi});
-        return df1;
+        return df2;
     }
 }
 
@@ -360,6 +366,10 @@ ROOT::RDF::RNode GenerateDoubleTriggerFlag(
     const float &p2_eta_cut, const int &p1_trigger_particle_id_cut,
     const int &p2_trigger_particle_id_cut, const int &p1_triggerbit_cut,
     const int &p2_triggerbit_cut, const float &DeltaR_threshold) {
+    // In nanoAODv12 the type of trigger object ID was changed to UShort_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, p1_pt_cut, p2_pt_cut, p1_eta_cut,
                          p2_eta_cut, p1_trigger_particle_id_cut,
@@ -369,10 +379,11 @@ ROOT::RDF::RNode GenerateDoubleTriggerFlag(
                             const ROOT::Math::PtEtaPhiMVector &particle1_p4,
                             const ROOT::Math::PtEtaPhiMVector &particle2_p4,
                             ROOT::RVec<int> triggerobject_bits,
-                            ROOT::RVec<int> triggerobject_ids,
+                            ROOT::RVec<UShort_t> triggerobject_ids_v12,
                             ROOT::RVec<float> triggerobject_pts,
                             ROOT::RVec<float> triggerobject_etas,
                             ROOT::RVec<float> triggerobject_phis) {
+        auto triggerobject_ids = static_cast<ROOT::RVec<int>>(triggerobject_ids_v12);
         Logger::get("GenerateDoubleTriggerFlag")->debug("Checking Trigger");
         Logger::get("CheckTriggerMatch")
             ->debug("Selected trigger: {}", hltpath);
@@ -435,12 +446,12 @@ ROOT::RDF::RNode GenerateDoubleTriggerFlag(
     } else {
         Logger::get("GenerateDoubleTriggerFlag")
             ->debug("Found matching trigger: {}", matched_trigger_names[0]);
-        auto df1 =
-            df.Define(triggerflag_name, triggermatch,
+        auto df2 =
+            df1.Define(triggerflag_name, triggermatch,
                       {matched_trigger_names[0], particle1_p4, particle2_p4,
-                       triggerobject_bits, triggerobject_id, triggerobject_pt,
+                       triggerobject_bits, triggerobject_id_column, triggerobject_pt,
                        triggerobject_eta, triggerobject_phi});
-        return df1;
+        return df2;
     }
 }
 
@@ -501,6 +512,10 @@ ROOT::RDF::RNode MatchDoubleTriggerObject(
     const int &p1_trigger_particle_id_cut,
     const int &p2_trigger_particle_id_cut, const int &p1_triggerbit_cut,
     const int &p2_triggerbit_cut, const float &DeltaR_threshold) {
+    // In nanoAODv12 the type of trigger object ID was changed to UShort_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch =
         [DeltaR_threshold, p1_pt_cut, p2_pt_cut, p1_eta_cut, p2_eta_cut,
@@ -509,10 +524,11 @@ ROOT::RDF::RNode MatchDoubleTriggerObject(
          p2_triggerbit_cut](const ROOT::Math::PtEtaPhiMVector &particle1_p4,
                             const ROOT::Math::PtEtaPhiMVector &particle2_p4,
                             ROOT::RVec<int> triggerobject_bits,
-                            ROOT::RVec<int> triggerobject_ids,
+                            ROOT::RVec<UShort_t> triggerobject_ids_v12,
                             ROOT::RVec<float> triggerobject_pts,
                             ROOT::RVec<float> triggerobject_etas,
                             ROOT::RVec<float> triggerobject_phis) {
+            auto triggerobject_ids = static_cast<ROOT::RVec<int>>(triggerobject_ids_v12);
             bool match_result_p1 = false;
             bool match_result_p2 = false;
             Logger::get("MatchDoubleTriggerObject")
@@ -538,11 +554,11 @@ ROOT::RDF::RNode MatchDoubleTriggerObject(
                 ->debug("--->>>> result: {}", result);
             return result;
         };
-    auto df1 = df.Define(triggerflag_name, triggermatch,
+    auto df2 = df1.Define(triggerflag_name, triggermatch,
                          {particle1_p4, particle2_p4, triggerobject_bits,
-                          triggerobject_id, triggerobject_pt, triggerobject_eta,
+                          triggerobject_id_column, triggerobject_pt, triggerobject_eta,
                           triggerobject_phi});
-    return df1;
+    return df2;
 }
 
 /**
@@ -580,15 +596,20 @@ ROOT::RDF::RNode MatchSingleTriggerObject(
     const float &pt_cut, const float &eta_cut,
     const int &trigger_particle_id_cut, const int &triggerbit_cut,
     const float &DeltaR_threshold) {
+    // In nanoAODv12 the type of trigger object ID was changed to UShort_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, pt_cut, eta_cut,
                          trigger_particle_id_cut, triggerbit_cut](
                             const ROOT::Math::PtEtaPhiMVector &particle_p4,
                             ROOT::RVec<int> triggerobject_bits,
-                            ROOT::RVec<int> triggerobject_ids,
+                            ROOT::RVec<UShort_t> triggerobject_ids_v12,
                             ROOT::RVec<float> triggerobject_pts,
                             ROOT::RVec<float> triggerobject_etas,
                             ROOT::RVec<float> triggerobject_phis) {
+        auto triggerobject_ids = static_cast<ROOT::RVec<int>>(triggerobject_ids_v12);
         Logger::get("MatchSingleTriggerObject")->debug("Checking Trigger");
         Logger::get("MatchSingleTriggerObject")
             ->debug("Checking Triggerobject match with particles ....");
@@ -601,11 +622,11 @@ ROOT::RDF::RNode MatchSingleTriggerObject(
             ->debug("--->>>> match_result: {}", match_result);
         return match_result;
     };
-    auto df1 =
-        df.Define(triggerflag_name, triggermatch,
-                  {particle_p4, triggerobject_bits, triggerobject_id,
+    auto df2 =
+        df1.Define(triggerflag_name, triggermatch,
+                  {particle_p4, triggerobject_bits, triggerobject_id_column,
                    triggerobject_pt, triggerobject_eta, triggerobject_phi});
-    return df1;
+    return df2;
 }
 
 namespace tagandprobe {
@@ -760,16 +781,21 @@ ROOT::RDF::RNode MatchSingleTriggerObject(
     const float &pt_cut, const float &eta_cut,
     const int &trigger_particle_id_cut, const int &triggerbit_cut,
     const float &DeltaR_threshold, const float &trigger_particle_pt_cut) {
+    // In nanoAODv12 the type of trigger object ID was changed to UShort_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, pt_cut, eta_cut,
                          trigger_particle_id_cut, triggerbit_cut,
                          trigger_particle_pt_cut](
                             const ROOT::Math::PtEtaPhiMVector &particle_p4,
                             ROOT::RVec<int> triggerobject_bits,
-                            ROOT::RVec<int> triggerobject_ids,
+                            ROOT::RVec<UShort_t> triggerobject_ids_v12,
                             ROOT::RVec<float> triggerobject_pts,
                             ROOT::RVec<float> triggerobject_etas,
                             ROOT::RVec<float> triggerobject_phis) {
+        auto triggerobject_ids = static_cast<ROOT::RVec<int>>(triggerobject_ids_v12);
         Logger::get("MatchSingleTriggerObject")->debug("Checking Trigger");
         Logger::get("MatchSingleTriggerObject")
             ->debug("Checking Triggerobject match with particles ....");
@@ -782,11 +808,11 @@ ROOT::RDF::RNode MatchSingleTriggerObject(
             ->debug("--->>>> match_result: {}", match_result);
         return match_result;
     };
-    auto df1 =
-        df.Define(triggerflag_name, triggermatch,
-                  {particle_p4, triggerobject_bits, triggerobject_id,
+    auto df2 =
+        df1.Define(triggerflag_name, triggermatch,
+                  {particle_p4, triggerobject_bits, triggerobject_id_column,
                    triggerobject_pt, triggerobject_eta, triggerobject_phi});
-    return df1;
+    return df2;
 }
 
 /**
@@ -829,16 +855,21 @@ ROOT::RDF::RNode GenerateSingleTriggerFlag(
     const std::string &hltpath, const float &pt_cut, const float &eta_cut,
     const int &trigger_particle_id_cut, const int &triggerbit_cut,
     const float &DeltaR_threshold, const float &trigger_particle_pt_cut) {
+    // In nanoAODv12 the type of trigger object ID was changed to UShort_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch =
         [DeltaR_threshold, pt_cut, eta_cut, trigger_particle_id_cut,
          triggerbit_cut, trigger_particle_pt_cut, hltpath](
             bool hltpath_match, const ROOT::Math::PtEtaPhiMVector &particle_p4,
             ROOT::RVec<int> triggerobject_bits,
-            ROOT::RVec<int> triggerobject_ids,
+            ROOT::RVec<UShort_t> triggerobject_ids_v12,
             ROOT::RVec<float> triggerobject_pts,
             ROOT::RVec<float> triggerobject_etas,
             ROOT::RVec<float> triggerobject_phis) {
+            auto triggerobject_ids = static_cast<ROOT::RVec<int>>(triggerobject_ids_v12);
             Logger::get("GenerateSingleTriggerFlag")->debug("Checking Trigger");
             Logger::get("CheckTriggerMatch")
                 ->debug("Selected trigger: {}", hltpath);
@@ -891,12 +922,12 @@ ROOT::RDF::RNode GenerateSingleTriggerFlag(
     } else {
         Logger::get("GenerateSingleTriggerFlag")
             ->debug("Found matching trigger: {}", matched_trigger_names[0]);
-        auto df1 =
-            df.Define(triggerflag_name, triggermatch,
+        auto df2 =
+            df1.Define(triggerflag_name, triggermatch,
                       {matched_trigger_names[0], particle_p4,
-                       triggerobject_bits, triggerobject_id, triggerobject_pt,
+                       triggerobject_bits, triggerobject_id_column, triggerobject_pt,
                        triggerobject_eta, triggerobject_phi});
-        return df1;
+        return df2;
     }
 }
 /**
@@ -966,6 +997,10 @@ ROOT::RDF::RNode GenerateDoubleTriggerFlag(
     const int &p2_triggerbit_cut, const float &DeltaR_threshold,
     const float &p1_trigger_particle_pt_cut,
     const float &p2_trigger_particle_pt_cut) {
+    // In nanoAODv12 the type of trigger object ID was changed to UShort_t
+    // For v9 compatibility a type casting is applied
+    auto [df1, triggerobject_id_column] = utility::Cast<ROOT::RVec<UShort_t>, ROOT::RVec<Int_t>>(
+            df, triggerobject_id+"_v12", "ROOT::RVec<UShort_t>", triggerobject_id);
 
     auto triggermatch = [DeltaR_threshold, p1_pt_cut, p2_pt_cut, p1_eta_cut,
                          p2_eta_cut, p1_trigger_particle_id_cut,
@@ -976,10 +1011,11 @@ ROOT::RDF::RNode GenerateDoubleTriggerFlag(
                             const ROOT::Math::PtEtaPhiMVector &particle1_p4,
                             const ROOT::Math::PtEtaPhiMVector &particle2_p4,
                             ROOT::RVec<int> triggerobject_bits,
-                            ROOT::RVec<int> triggerobject_ids,
+                            ROOT::RVec<UShort_t> triggerobject_ids_v12,
                             ROOT::RVec<float> triggerobject_pts,
                             ROOT::RVec<float> triggerobject_etas,
                             ROOT::RVec<float> triggerobject_phis) {
+        auto triggerobject_ids = static_cast<ROOT::RVec<int>>(triggerobject_ids_v12);
         Logger::get("GenerateDoubleTriggerFlag")->debug("Checking Trigger");
         Logger::get("CheckTriggerMatch")
             ->debug("Selected trigger: {}", hltpath);
@@ -1044,12 +1080,12 @@ ROOT::RDF::RNode GenerateDoubleTriggerFlag(
     } else {
         Logger::get("GenerateDoubleTriggerFlag")
             ->debug("Found matching trigger: {}", matched_trigger_names[0]);
-        auto df1 =
-            df.Define(triggerflag_name, triggermatch,
+        auto df2 =
+            df1.Define(triggerflag_name, triggermatch,
                       {matched_trigger_names[0], particle1_p4, particle2_p4,
-                       triggerobject_bits, triggerobject_id, triggerobject_pt,
+                       triggerobject_bits, triggerobject_id_column, triggerobject_pt,
                        triggerobject_eta, triggerobject_phi});
-        return df1;
+        return df2;
     }
 }
 


### PR DESCRIPTION
This PR introduces changes to C++ function to be usable with nanoAOD v9 and v12.
One of the differences is related to some branches having a different type in v12: 
`Int_t` -> `UChar_t`
`Int_t` -> `Short_t`
`Int_t` -> `UShort_t`