### PR TITLE
Functions for tau corrections in Run 3

### DIFF
--- a/include/taus.hxx
+++ b/include/taus.hxx
@@ -27,8 +27,6 @@ PtCorrectionMC(
     const std::string &gen_match, const std::string &es_file,
     const std::string &correction_name,
     const std::string &id_algorithm,
-    const std::string &id_vs_jet_wp,
-    const std::string &id_vs_ele_wp,
     const std::string &variation_efake_dm0_barrel,
     const std::string &variation_efake_dm1_barrel,
     const std::string &variation_efake_dm0_endcap,
@@ -37,7 +35,9 @@ PtCorrectionMC(
     const std::string &variation_gentau_dm0,
     const std::string &variation_gentau_dm1,
     const std::string &variation_gentau_dm10,
-    const std::string &variation_gentau_dm11
+    const std::string &variation_gentau_dm11,
+    const std::string &id_vs_jet_wp = "",
+    const std::string &id_vs_ele_wp = ""
 );
 ROOT::RDF::RNode
 PtCorrectionMC_eleFake(ROOT::RDF::RNode df,
@@ -150,6 +150,16 @@ Trigger(ROOT::RDF::RNode df,
         correctionManager::CorrectionManager &correction_manager,
         const std::string &outputname,
         const std::string &pt, const std::string &decay_mode, 
+        const std::string &sf_file,
+        const std::string &sf_name,
+        const std::string &trigger_name, const std::string &wp,
+        const std::string &corr_type, const std::string &variation);
+ROOT::RDF::RNode
+Trigger(ROOT::RDF::RNode df,
+        correctionManager::CorrectionManager &correction_manager,
+        const std::string &outputname,
+        const std::string &pt, const std::string &decay_mode, 
+        const std::string &trigger_flag,
         const std::string &sf_file,
         const std::string &sf_name,
         const std::string &trigger_name, const std::string &wp,

--- a/include/taus.hxx
+++ b/include/taus.hxx
@@ -120,7 +120,17 @@ Id_vsEle(ROOT::RDF::RNode df,
          const std::string &wp, 
          const std::string &sf_vsele_barrel,
          const std::string &sf_vsele_endcap);
-
+ROOT::RDF::RNode
+Id_vsEle(ROOT::RDF::RNode df,
+    correctionManager::CorrectionManager &correction_manager,
+    const std::string &outputname,
+    const std::string &eta,
+    const std::string &decay_mode,
+    const std::string &gen_match, 
+    const std::string &sf_file, const std::string &sf_name,
+    const std::string &wp, 
+    const std::string &variation_barrel,
+    const std::string &variation_endcap);
 ROOT::RDF::RNode
 Id_vsMu(ROOT::RDF::RNode df,
         correctionManager::CorrectionManager &correction_manager,

--- a/include/taus.hxx
+++ b/include/taus.hxx
@@ -4,6 +4,41 @@
 namespace physicsobject {
 namespace tau {
 
+std::string get_tes_variation(
+    const float &abs_eta,
+    const int &decay_mode,
+    const int &gen_match,
+    const std::string &variation_efake_dm0_barrel,
+    const std::string &variation_efake_dm1_barrel,
+    const std::string &variation_efake_dm0_endcap,
+    const std::string &variation_efake_dm1_endcap,
+    const std::string &variation_mufake,
+    const std::string &variation_gentau_dm0,
+    const std::string &variation_gentau_dm1,
+    const std::string &variation_gentau_dm10,
+    const std::string &variation_gentau_dm11
+);
+ROOT::RDF::RNode
+PtCorrectionMC(
+    ROOT::RDF::RNode df,
+    correctionManager::CorrectionManager &correction_manager,
+    const std::string &outputname, const std::string &pt,
+    const std::string &eta, const std::string &decay_mode,
+    const std::string &gen_match, const std::string &es_file,
+    const std::string &correction_name,
+    const std::string &id_algorithm,
+    const std::string &id_vs_jet_wp,
+    const std::string &id_vs_ele_wp,
+    const std::string &variation_efake_dm0_barrel,
+    const std::string &variation_efake_dm1_barrel,
+    const std::string &variation_efake_dm0_endcap,
+    const std::string &variation_efake_dm1_endcap,
+    const std::string &variation_mufake,
+    const std::string &variation_gentau_dm0,
+    const std::string &variation_gentau_dm1,
+    const std::string &variation_gentau_dm10,
+    const std::string &variation_gentau_dm11
+);
 ROOT::RDF::RNode
 PtCorrectionMC_eleFake(ROOT::RDF::RNode df,
                        correctionManager::CorrectionManager &correction_manager,

--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -224,29 +224,21 @@ PtCorrectionMC(
     auto evaluator =
         correction_manager.loadCorrection(es_file, correction_name);
 
-    // set the variation depending on the gen match, decay mode, and barrel/endcap region
-    std::string variation = get_tes_variation(
-        abs_eta,
-        decay_mode,
-        gen_match,
-        variation_efake_dm0_barrel,
-        variation_efake_dm1_barrel,
-        variation_efake_dm0_endcap,
-        variation_efake_dm1_endcap,
-        variation_mufake,
-        variation_gentau_dm0,
-        variation_gentau_dm1,
-        variation_gentau_dm10,
-        variation_gentau_dm11
-    );
-
     auto correction_lambda =
         [
             evaluator,
             id_algorithm,
             id_vs_jet_wp,
             id_vs_ele_wp,
-            variation
+            variation_efake_dm0_barrel,
+            variation_efake_dm1_barrel,
+            variation_efake_dm0_endcap,
+            variation_efake_dm1_endcap,
+            variation_mufake,
+            variation_gentau_dm0,
+            variation_gentau_dm1,
+            variation_gentau_dm10,
+            variation_gentau_dm11
         ] (
             const ROOT::RVec<float> &pts,
             const ROOT::RVec<float> &etas,
@@ -266,6 +258,22 @@ PtCorrectionMC(
                 auto abs_eta = etas.at(i);
                 auto decay_mode = decay_modes.at(i);
                 auto gen_match = gen_matches.at(i);
+
+                // set the variation depending on the gen match, decay mode, and barrel/endcap region
+                std::string variation = get_tes_variation(
+                    abs_eta,
+                    decay_mode,
+                    gen_match,
+                    variation_efake_dm0_barrel,
+                    variation_efake_dm1_barrel,
+                    variation_efake_dm0_endcap,
+                    variation_efake_dm1_endcap,
+                    variation_mufake,
+                    variation_gentau_dm0,
+                    variation_gentau_dm1,
+                    variation_gentau_dm10,
+                    variation_gentau_dm11
+                );
 
                 // evaluate the correction factor
                 // ensure that the tau fulfills the selection criteria for application of the correction,

--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -1287,6 +1287,9 @@ Id_vsMu(ROOT::RDF::RNode df,
  * scale factor and "up"/"down" for the up/down variation
  *
  * @return a new dataframe containing the new column
+ *
+ * @warning This function is deprecated. Use the overloaded function with the additional
+ * parameter `trigger_flag` instead.
  */
 ROOT::RDF::RNode
 Trigger(ROOT::RDF::RNode df,
@@ -1297,7 +1300,8 @@ Trigger(ROOT::RDF::RNode df,
         const std::string &sf_name,
         const std::string &trigger_name, const std::string &wp,
         const std::string &corr_type, const std::string &variation) {
-
+    Logger::get("physicsobject::tau::scalefactor::Trigger")
+        ->warn("Function is deprecated, use the overloaded version instead");
     Logger::get("physicsobject::tau::scalefactor::Trigger")
         ->debug("Setting up function for tau trigger sf");
     Logger::get("physicsobject::tau::scalefactor::Trigger")

--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -1043,6 +1043,12 @@ Id_vsEle(ROOT::RDF::RNode df,
     auto sf_calculator = [evaluator, wp, variation_barrel, variation_endcap,
                             sf_name](const float &eta, const int &gen_match) {
         double sf = 1.;
+
+        // set edges of barrel and endcap region
+        double max_abs_eta_barrel = 1.46;
+        double min_abs_eta_endcap = 1.558;
+        double max_abs_eta_endcap = 2.3;
+
         // exclude default values due to tau energy correction shifts below good tau
         // pt selection
         if (eta > -5.0) {
@@ -1053,10 +1059,10 @@ Id_vsEle(ROOT::RDF::RNode df,
                         variation_endcap);
             // the eta cuts are taken from the correctionlib json file to define 
             // barrel and endcap
-            if (std::abs(eta) < 1.46) {
+            if (std::abs(eta) < max_abs_eta_barrel) {
                 sf = evaluator->evaluate(
                     {eta, gen_match, wp, variation_barrel});
-            } else if (std::abs(eta) >= 1.558 && std::abs(eta) < 2.3) {
+            } else if (std::abs(eta) >= min_abs_eta_endcap && std::abs(eta) < max_abs_eta_endcap) {
                 sf = evaluator->evaluate(
                     {eta, gen_match, wp, variation_endcap});
             } else {

--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -272,7 +272,6 @@ PtCorrectionMC(
                 // set the correction factor to 1 otherwise
                 float correction_factor = 1.0;
                 const std::unordered_set<int> valid_modes = {0, 1, 2, 10, 11};
-
                 if (valid_modes.count(decay_mode)) {
                     if ((id_vs_jet_wp == "") && (id_vs_ele_wp == "")) {
                         correction_factor = evaluator->evaluate(

--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -271,13 +271,9 @@ PtCorrectionMC(
                 // ensure that the tau fulfills the selection criteria for application of the correction,
                 // set the correction factor to 1 otherwise
                 float correction_factor = 1.0;
-                if (
-                    (decay_mode == 0)
-                    || (decay_mode == 1)
-                    || (decay_mode == 2)
-                    || (decay_mode == 10)
-                    || (decay_mode == 11)
-                ) {
+                const std::unordered_set<int> valid_modes = {0, 1, 2, 10, 11};
+
+                if (valid_modes.count(decay_mode)) {
                     if ((id_vs_jet_wp == "") && (id_vs_ele_wp == "")) {
                         correction_factor = evaluator->evaluate(
                             {

--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -223,21 +223,30 @@ PtCorrectionMC(
 
     auto evaluator =
         correction_manager.loadCorrection(es_file, correction_name);
+
+    // set the variation depending on the gen match, decay mode, and barrel/endcap region
+    std::string variation = get_tes_variation(
+        abs_eta,
+        decay_mode,
+        gen_match,
+        variation_efake_dm0_barrel,
+        variation_efake_dm1_barrel,
+        variation_efake_dm0_endcap,
+        variation_efake_dm1_endcap,
+        variation_mufake,
+        variation_gentau_dm0,
+        variation_gentau_dm1,
+        variation_gentau_dm10,
+        variation_gentau_dm11
+    );
+
     auto correction_lambda =
         [
             evaluator,
             id_algorithm,
             id_vs_jet_wp,
             id_vs_ele_wp,
-            variation_efake_dm0_barrel,
-            variation_efake_dm1_barrel,
-            variation_efake_dm0_endcap,
-            variation_efake_dm1_endcap,
-            variation_mufake,
-            variation_gentau_dm0,
-            variation_gentau_dm1,
-            variation_gentau_dm10,
-            variation_gentau_dm11
+            variation
         ] (
             const ROOT::RVec<float> &pts,
             const ROOT::RVec<float> &etas,
@@ -257,22 +266,6 @@ PtCorrectionMC(
                 auto abs_eta = etas.at(i);
                 auto decay_mode = decay_modes.at(i);
                 auto gen_match = gen_matches.at(i);
-
-                // set the variation depending on the gen match, decay mode, and 
-                std::string variation = get_tes_variation(
-                    abs_eta,
-                    decay_mode,
-                    gen_match,
-                    variation_efake_dm0_barrel,
-                    variation_efake_dm1_barrel,
-                    variation_efake_dm0_endcap,
-                    variation_efake_dm1_endcap,
-                    variation_mufake,
-                    variation_gentau_dm0,
-                    variation_gentau_dm1,
-                    variation_gentau_dm10,
-                    variation_gentau_dm11
-                );
 
                 // evaluate the correction factor
                 // ensure that the tau fulfills the selection criteria for application of the correction,

--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -121,7 +121,7 @@ std::string get_tes_variation(
  * points of the `DeepTau` algorithm, regarding the identification against
  * jets and against electrons. This is not the case for Run 2 analyses. This
  * function can be used for both Run 2 and Run 3 analyses. For Run 2 analyses,
- * the values of `id_vs_jet_wp` and `id_vs_ele_wp` can be set to `nullptr`
+ * the values of `id_vs_jet_wp` and `id_vs_ele_wp` can be set to `""`
  * to obtain the corrections.
  * 
  * The uncertainty scheme is split into nine different uncertainty sources:
@@ -165,8 +165,8 @@ std::string get_tes_variation(
  * @param es_file path to the correction file for the energy scale correction
  * @param correction_name name of the correction in `es_file`
  * @param id_algorithm identification algorithm used for hadronic tau ID
- * @param id_vs_jet_wp working point for the identification against jets; set to `nullptr` if the corrections do not depend on this parameter
- * @param id_vs_ele_wp working point for the identification against electrons; set to `nullptr` if the corrections do not depend on this parameter
+ * @param id_vs_jet_wp working point for the identification against jets; set to `""` if the corrections do not depend on this parameter
+ * @param id_vs_ele_wp working point for the identification against electrons; set to `""` if the corrections do not depend on this parameter
  * @param variation_efake_dm0_barrel variation for electron faking a tau for decay mode 0 in the barrel region,
  * options are "nom", "up", "down"
  * @param variation_efake_dm1_barrel variation for electron faking a tau for decay mode 1 in the barrel region,
@@ -284,7 +284,7 @@ PtCorrectionMC(
                     || (decay_mode == 10)
                     || (decay_mode == 11)
                 ) {
-                    if ((id_vs_jet_wp == nullptr) && (id_vs_ele_wp == nullptr)) {
+                    if ((id_vs_jet_wp == "") && (id_vs_ele_wp == "")) {
                         correction_factor = evaluator->evaluate(
                             {
                                 pt,

--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -204,8 +204,6 @@ PtCorrectionMC(
     const std::string &es_file,
     const std::string &correction_name,
     const std::string &id_algorithm,
-    const std::string &id_vs_jet_wp,
-    const std::string &id_vs_ele_wp,
     const std::string &variation_efake_dm0_barrel,
     const std::string &variation_efake_dm1_barrel,
     const std::string &variation_efake_dm0_endcap,
@@ -214,7 +212,9 @@ PtCorrectionMC(
     const std::string &variation_gentau_dm0,
     const std::string &variation_gentau_dm1,
     const std::string &variation_gentau_dm10,
-    const std::string &variation_gentau_dm11
+    const std::string &variation_gentau_dm11,
+    const std::string &id_vs_jet_wp = "",
+    const std::string &id_vs_ele_wp = ""
 ) {
     // In nanoAODv12 the type of tau decay mode was changed to UChar_t
     // For v9 compatibility a type casting is applied


### PR DESCRIPTION
Compared to Run 2, the tau energy corrections in Run 3 additionally depend on the DeepTau working points for ID vs electrons and ID vs jets. The scale factor for DeepTau ID vs electrons additionally depends on the decay mode of the tau. The functions in CROWN are adapted to this change:

- `PtCorrectionMC` is a new function for evaluating the tau energy corrections in Run 3. All steps, previously split in corrections for electron fakes, muon fakes, and genuine taus, are performed inside this single function now. The helper function `get_tes_variation` is used to return the correct variation, depending on the generator match to the reconstructed tau, the decay mode, and the region in the detector.
- An overloaded version `Id_vsEle` has been added, now also containing the decay mode of the tau as input parameter.