### PR TITLE
Additional muon trigger scale factor function

### DIFF
--- a/include/muons.hxx
+++ b/include/muons.hxx
@@ -42,6 +42,13 @@ Trigger(ROOT::RDF::RNode df,
         const std::string &outputname, const std::string &pt,
         const std::string &eta, const std::string &sf_file,
         const std::string &sf_name, const std::string &variation);
+ROOT::RDF::RNode
+Trigger(ROOT::RDF::RNode df,
+        correctionManager::CorrectionManager &correction_manager,
+        const std::string &outputname, const std::string &pt,
+        const std::string &eta, const std::string &trigger_flag,
+        const std::string &sf_file, const std::string &sf_name,
+        const std::string &variation);
 } // end namespace scalefactor
 } // end namespace muon
 } // end namespace physicsobject

--- a/src/muons.cxx
+++ b/src/muons.cxx
@@ -383,7 +383,7 @@ Trigger(ROOT::RDF::RNode df,
 
 /**
  * @brief This function calculates muon trigger scale factors (SFs) for a single
- * muon dependening on its pseudorapidity (\f$\eta\f$) and transverse momentum
+ * muon depending on its pseudorapidity (\f$\eta\f$) and transverse momentum
  * (\f$p_T\f$). The scale factors are loaded from a correctionlib file using a
  * specified scale factor name and variation. This function only uses the scale
  * factor from the correctionlib evaluation if the corresponding trigger flag

--- a/src/muons.cxx
+++ b/src/muons.cxx
@@ -339,6 +339,9 @@ ROOT::RDF::RNode Iso(ROOT::RDF::RNode df,
  * scale factor and "systup"/"systdown" for the up/down variation
  *
  * @return a new dataframe containing the new column
+ *
+ * @warning This function is deprecated. Use the overloaded function with the additional
+ * parameter `trigger_flag` instead.
  */
 ROOT::RDF::RNode
 Trigger(ROOT::RDF::RNode df,
@@ -346,6 +349,8 @@ Trigger(ROOT::RDF::RNode df,
         const std::string &outputname, const std::string &pt,
         const std::string &eta, const std::string &sf_file,
         const std::string &sf_name, const std::string &variation) {
+    Logger::get("physicsobject::muon::scalefactor::Trigger")
+        ->warn("Function is deprecated, use the overloaded version instead");
     Logger::get("physicsobject::muon::scalefactor::Trigger")
         ->debug("Setting up functions for muon trigger sf");
     Logger::get("physicsobject::muon::scalefactor::Trigger")


### PR DESCRIPTION
This pull request adds a function for trigger scale factor evaluation that takes the trigger flag as additional input column. The scale factor is only evaluated when the trigger flag is set to true, i.e., when the trigger has fired. Otherwise, the scale factor is set to 1. This mitigates implementing acceptance conditions of the trigger directly in the C++ function.