### PR TITLE
Update to LCG 108 stack with cpp 15

### DIFF
--- a/cmake/AddRoot.cmake
+++ b/cmake/AddRoot.cmake
@@ -1,4 +1,4 @@
-find_package(ROOT 6.30 REQUIRED COMPONENTS ROOTVecOps ROOTDataFrame RooFit GenVector)
+find_package(ROOT 6.36 REQUIRED COMPONENTS ROOTVecOps ROOTDataFrame RooFit GenVector Minuit)
 
 message(STATUS "")
 message(STATUS "Found ROOT with following settings:")

--- a/cmake/Build.cmake
+++ b/cmake/Build.cmake
@@ -56,6 +56,7 @@ foreach(FILENAME ${FILELIST})
     ROOT::ROOTDataFrame
     ROOT::RooFit
     ROOT::GenVector
+    ROOT::Minuit
     logging
     correctionlib
     nlohmann_json::nlohmann_json

--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -10,7 +10,7 @@
 #include <TObjString.h>
 #include <TTree.h>
 #include <TVector.h>
-#include "onnxruntime_cxx_api.h"
+#include "onnxruntime/onnxruntime_cxx_api.h"
 #include <regex>
 #include <string>
 #include "include/utility/OnnxSessionManager.hxx"
@@ -42,9 +42,9 @@ int main(int argc, char *argv[]) {
     // {DEBUGLEVEL}
     // ROOT logging
     if (debug) {
-        auto verbosity = ROOT::Experimental::RLogScopedVerbosity(
+        auto verbosity = ROOT::RLogScopedVerbosity(
             ROOT::Detail::RDF::RDFLogChannel(),
-            ROOT::Experimental::ELogLevel::kInfo);
+            ROOT::ELogLevel::kInfo);
         RooTrace::verbose(kTRUE);
         Logger::setLevel(Logger::LogLevel::DEBUG);
     } else {

--- a/code_generation/analysis_template_friends.cxx
+++ b/code_generation/analysis_template_friends.cxx
@@ -10,7 +10,7 @@
 #include <TObjString.h>
 #include <TTree.h>
 #include <TVector.h>
-#include "onnxruntime_cxx_api.h"
+#include "onnxruntime/onnxruntime_cxx_api.h"
 #include <regex>
 #include <string>
 #include "include/utility/OnnxSessionManager.hxx"
@@ -81,9 +81,9 @@ int main(int argc, char *argv[]) {
     // {DEBUGLEVEL}
     // ROOT logging
     if (debug) {
-        auto verbosity = ROOT::Experimental::RLogScopedVerbosity(
+        auto verbosity = ROOT::RLogScopedVerbosity(
             ROOT::Detail::RDF::RDFLogChannel(),
-            ROOT::Experimental::ELogLevel::kInfo);
+            ROOT::ELogLevel::kInfo);
         RooTrace::verbose(kTRUE);
         Logger::setLevel(Logger::LogLevel::DEBUG);
     } else {

--- a/code_generation/subset_template.cxx
+++ b/code_generation/subset_template.cxx
@@ -10,7 +10,7 @@
 #include <TObjString.h>
 #include <TTree.h>
 #include <TVector.h>
-#include "onnxruntime_cxx_api.h"
+#include "onnxruntime/onnxruntime_cxx_api.h"
 #include <regex>
 #include <string>
 #include "include/utility/OnnxSessionManager.hxx"

--- a/include/utility/OnnxSessionManager.hxx
+++ b/include/utility/OnnxSessionManager.hxx
@@ -3,7 +3,7 @@
 
 #include "Logger.hxx"
 #include <memory>
-#include <onnxruntime_cxx_api.h>
+#include <onnxruntime/onnxruntime_cxx_api.h>
 #include <string>
 #include <unordered_map>
 

--- a/init.sh
+++ b/init.sh
@@ -35,7 +35,7 @@ elif [[ "$distro" == "RedHatEnterprise" || "$distro" == "Alma" || "$distro" == "
         echo "Unsupported CentOS version, exiting..."
         return 0
     elif [[ ${os_version:0:1} == "9" ]]; then # elif uname -a | grep -E 'el8' -q
-        source /cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt/setup.sh
+        source /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/setup.sh
     else
         echo "Unsupported CentOS version, exiting..."
         return 0

--- a/src/ml.cxx
+++ b/src/ml.cxx
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <memory>
 #include <nlohmann/json.hpp>
-#include <onnxruntime_cxx_api.h>
+#include <onnxruntime/onnxruntime_cxx_api.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/utility/OnnxSessionManager.cxx
+++ b/src/utility/OnnxSessionManager.cxx
@@ -2,7 +2,7 @@
 #include "../../include/utility/utility.hxx"
 #include <memory>
 #include <numeric>
-#include <onnxruntime_cxx_api.h>
+#include <onnxruntime/onnxruntime_cxx_api.h>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
This PR updates the environment to the newest LCG stack and cpp available. Some changes in the ONNX and ROOT paths are introduced, alongside explicitly adding Minuit as ROOT package. All other dependencies are unchanged.