### PR TITLE
Length of a vector quantity

### DIFF
--- a/include/physicsobjects.hxx
+++ b/include/physicsobjects.hxx
@@ -302,6 +302,28 @@ CutQuantity(ROOT::RDF::RNode df, const std::string &outputname,
         {quantity});
 }
 
+/**
+ * @brief This function returns the length of the vector containers in columns
+ * that contain `ROOT::VecOps::RVec<T>` objects. The function is templated
+ * with `T`, which must be set to the underlying type of the vector object.
+ *
+ * @param df input dataframe
+ * @param outputname name of the output column storing the object count
+ * @param vector_quantity name of the quantity stored in vector structures
+ *
+ * @return a dataframe with a new column
+ */
+template <typename T>
+ROOT::RDF::RNode Size(ROOT::RDF::RNode df, const std::string &outputname,
+                       const std::string &vector_quantity) {
+    return df.Define(outputname,
+                     [](const ROOT::RVec<T> &quantity) {
+                         int length = quantity.size();
+                         return length;
+                     },
+                     {vector_quantity});
+}
+
 ROOT::RDF::RNode CutQuantityBarrelEndcap(
     ROOT::RDF::RNode df, const std::string &outputname, const std::string &eta,
     const std::string &quantity, const float &barrel_endcap_boundary,


### PR DESCRIPTION
This pull request adds a function that calculates the length of `ROOT::VecOps::RVec<T>` objects in a column and saves it to a new one. The function is included as template `physicsobject::Size<T>`, where `T` is the underlying data type of the `RVec` , i.e., for a column containing `RVec<int>` objects, `physicsobject::Size<int>` must be called.

This function should replace occasions of `physicsobject::Count` when the collection is represented by an index list instead of a boolean mask.