### PR TITLE
B jet and AK8 jet related features + updating jsonpog repo

### DIFF
--- a/code_generation/analysis_template.cxx
+++ b/code_generation/analysis_template.cxx
@@ -18,6 +18,7 @@
 #include "include/genparticles.hxx"
 #include "include/htxs.hxx"
 #include "include/jets.hxx"
+#include "include/fatjets.hxx"
 #include "include/event.hxx"
 #include "include/lorentzvectors.hxx"
 #include "include/met.hxx"

--- a/code_generation/analysis_template_friends.cxx
+++ b/code_generation/analysis_template_friends.cxx
@@ -18,6 +18,7 @@
 #include "include/genparticles.hxx"
 #include "include/htxs.hxx"
 #include "include/jets.hxx"
+#include "include/fatjets.hxx"
 #include "include/lorentzvectors.hxx"
 #include "include/met.hxx"
 #include "include/ml.hxx"

--- a/code_generation/subset_template.cxx
+++ b/code_generation/subset_template.cxx
@@ -18,6 +18,7 @@
 #include "include/genparticles.hxx"
 #include "include/htxs.hxx"
 #include "include/jets.hxx"
+#include "include/fatjets.hxx"
 #include "include/event.hxx"
 #include "include/lorentzvectors.hxx"
 #include "include/met.hxx"

--- a/include/fatjets.hxx
+++ b/include/fatjets.hxx
@@ -1,0 +1,25 @@
+#ifndef GUARD_FATJETS_H
+#define GUARD_FATJETS_H
+
+namespace physicsobject {
+namespace fatjet {
+namespace quantity {
+
+ROOT::RDF::RNode
+ParticleNet_XvsQCD(ROOT::RDF::RNode df,
+    const std::string &outputname,
+    const std::string &pNet_X_decay,
+    const std::string &pNet_QCD,
+    const std::string &fatjet_collection,
+    const int &position);
+ROOT::RDF::RNode
+NsubjettinessRatio(ROOT::RDF::RNode df,
+    const std::string &outputname,
+    const std::string &tau_N,
+    const std::string &tau_Nm1,
+    const std::string &fatjet_collection,
+    const int &position);
+} // end namespace quantity
+} // end namespace fatjet
+} // end namespace physicsobject
+#endif /* GUARD_FATJETS_H */

--- a/include/jets.hxx
+++ b/include/jets.hxx
@@ -26,6 +26,12 @@ PtCorrectionData(ROOT::RDF::RNode df,
                  const std::string &jet_raw_factor, const std::string &rho,
                  const std::string &jec_file, const std::string &jec_algo,
                  const std::string &jes_tag);
+ROOT::RDF::RNode
+PtCorrectionBJets(ROOT::RDF::RNode df,
+                  const std::string &outputname,
+                  const std::string &jet_pt,
+                  const std::string &scale_factor,
+                  const std::string &bjet_mask);
 ROOT::RDF::RNode CutPileupID(ROOT::RDF::RNode df, const std::string &outputname,
                              const std::string &jet_pu_id,
                              const std::string &jet_pt, const int &pu_id_cut,

--- a/src/fatjets.cxx
+++ b/src/fatjets.cxx
@@ -1,0 +1,115 @@
+#ifndef GUARD_FATJETS_H
+#define GUARD_FATJETS_H
+
+#include "../include/defaults.hxx"
+#include "../include/utility/Logger.hxx"
+#include "../include/utility/utility.hxx"
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RVec.hxx"
+#include <Math/Vector3D.h>
+#include <Math/Vector4D.h>
+#include <Math/VectorUtil.h>
+#include <algorithm>
+
+namespace physicsobject {
+namespace fatjet {
+namespace quantity {
+
+/**
+ * @brief This function calculates a discriminator score from two ParticleNet 
+ * tagger outputs (a signal X and the QCD background). The signal can e.g. be 
+ * \f$X\rightarrow bb\f$ or \f$X\rightarrow cc\f$ etc. 
+ * 
+ * The score is computed using the formula: 
+ * \f[
+ * Score = \frac{P(X)}{P(X) + P(QCD)}
+ * \f]
+ *
+ * @param df input dataframe
+ * @param outputname name of the new column containing the XvsQCD score
+ * @param pNet_X_decay name of the column containing the ParticleNet score for 
+ * the signal process (\f$X\rightarrow ...\f$)
+ * @param pNet_QCD name of the column containing the ParticleNet score for the 
+ * QCD background
+ * @param fatjet_collection name of the column containing a collection (vector) 
+ * of good fatjet indices
+ * @param position position of the fatjet in the collection (vector) that should 
+ * be used for the score calculation
+ *
+ * @return a new dataframe containing the new column
+ */
+ROOT::RDF::RNode
+ParticleNet_XvsQCD(ROOT::RDF::RNode df, const std::string &outputname,
+                     const std::string &pNet_X_decay, const std::string &pNet_QCD,
+                     const std::string &fatjet_collection, const int &position) {
+    return df.Define(outputname,
+                     [position](const ROOT::RVec<float> &X_tagger,
+                                const ROOT::RVec<float> &QCD_tagger,
+                                const ROOT::RVec<int> &fatjets) {
+                        float X_decay = default_float;
+                        float QCD = default_float;
+                        float X_vs_QCD = default_float;
+                        if (position >= 0) {
+                            const int index = fatjets.at(position);
+                            if (index >= 0) {
+                                X_decay = X_tagger.at(index);
+                                QCD = QCD_tagger.at(index);
+                                X_vs_QCD = X_decay / (X_decay + QCD);
+                            }
+                        }
+                        return X_vs_QCD;
+                     },
+                     {pNet_X_decay, pNet_QCD, fatjet_collection});
+}
+
+/**
+ * @brief This function calculates the ratio of two N-subjettiness variables 
+ * of one fatjet, typically used for discriminating jet substructure:
+ * \f[
+ * \tau_{ratio} = \frac{\tau_N}{\tau_{N-1}}
+ * \f]
+ * For example, \f$\tau_{21} = \tau_2 / \tau_1\f$ for 2-prong vs. 1-prong decay 
+ * identification. The resulting ratio is always between 0 and 1. If it is close 
+ * to 0, the jet is more likely to be a N-prong jet, while a value close to 1 
+ * indicates a (N-1)-prong jet.
+ *
+ * @param df input dataframe
+ * @param outputname name of the new column containing the N-subjettiness ratio
+ * @param tau_N name of the column containing the N-subjettiness variable for 
+ * the numerator with number `N`
+ * @param tau_Nm1 name of the column containing the N-subjettiness variable for 
+ * the denominator with number `N-1`
+ * @param fatjet_collection name of the column containing a collection (vector) 
+ * of good fatjet indices
+ * @param position position of the fatjet in the collection (vector) that should 
+ * be used for the ratio calculation
+ *
+ * @return a new dataframe containing the new column
+ */
+ROOT::RDF::RNode
+NsubjettinessRatio(ROOT::RDF::RNode df, const std::string &outputname,
+                    const std::string &tau_N, const std::string &tau_Nm1,
+                    const std::string &fatjet_collection, const int &position) {
+    return df.Define(outputname,
+                    [position](const ROOT::RVec<float> &tau_N,
+                               const ROOT::RVec<float> &tau_Nm1,
+                               const ROOT::RVec<int> &fatjets) {
+                        float nsubjet_N = default_float;
+                        float nsubjet_Nm1 = default_float;
+                        float ratio = default_float;
+                        if (position >= 0) { 
+                            const int index = fatjets.at(position);
+                            if (index >= 0) {
+                                nsubjet_N = tau_N.at(index);
+                                nsubjet_Nm1 = tau_Nm1.at(index);
+                                ratio = nsubjet_N / nsubjet_Nm1;
+                            }
+                        }
+                        return ratio;
+                    },
+                    {tau_N, tau_Nm1, fatjet_collection});
+}
+} // end namespace quantity
+} // end namespace fatjet
+} // end namespace physicsobject
+#endif /* GUARD_FATJETS_H */

--- a/src/fatjets.cxx
+++ b/src/fatjets.cxx
@@ -25,6 +25,9 @@ namespace quantity {
  * Score = \frac{P(X)}{P(X) + P(QCD)}
  * \f]
  *
+ * @note This function is mainly needed when working with `nanoAODv9`, in newer 
+ * versions this ratio is already included as a branch.
+ *
  * @param df input dataframe
  * @param outputname name of the new column containing the XvsQCD score
  * @param pNet_X_decay name of the column containing the ParticleNet score for 

--- a/src/jets.cxx
+++ b/src/jets.cxx
@@ -363,10 +363,15 @@ PtCorrectionData(ROOT::RDF::RNode df,
 /** 
  * @brief This function applies a b-jet energy regression. The \f$p_T\f$ correction 
  * is applied to all b-jets identified with a b-tagging algorithm, e.g. DeepJet.
+ * The goal of the regression is to better estimate the energy of b-jets because 
+ * compared to other jet flavors, b-jets have a significantly higher rate of leptons
+ * and therefore also neutrinos in the decay, which leads to a lower reconstructed energy.
  * The correction is determined with a neural network that was trained to simultaneously
- * estimate the b-jet energy and resolution. Ref. http://cds.cern.ch/record/2690804
+ * estimate the b-jet energy and resolution. The application can be done on top of the
+ * general jet energy scale corrections. Ref. http://cds.cern.ch/record/2690804
  *
- * @note This function should only be used for Run2 since it is not present in Run3.
+ * @note This function should only be used for Run2 since the regression was not further
+ * developed for Run3 and is also not present in the nanoAODs anymore.
  *
  * @param df input dataframe
  * @param outputname name of the output column for corrected b-jet \f$p_T\f$'s

--- a/src/jets.cxx
+++ b/src/jets.cxx
@@ -388,28 +388,29 @@ ROOT::RDF::RNode PtCorrectionBJets(ROOT::RDF::RNode df,
                             const std::string &jet_pt, 
                             const std::string &scale_factor,
                             const std::string &bjet_mask) {
-    return df.Define(outputname,
-            [](const ROOT::RVec<float> &jet_pt, 
-               const ROOT::RVec<float> &scale_factor,
-               const ROOT::RVec<int> &bjet_mask) {
-            ROOT::RVec<float> pt_values_corrected;
-            for (int i = 0; i < jet_pt.size(); i++) {
-                float corr_pt = jet_pt.at(i);
+    auto bjet_pt_correction = [](const ROOT::RVec<float> &pts, 
+                                 const ROOT::RVec<float> &scale_factors,
+                                 const ROOT::RVec<int> &bjet_mask) {
+            ROOT::RVec<float> corrected_pts;
+            for (int i = 0; i < pts.size(); i++) {
+                float corr_pt = pts.at(i);
                 if (bjet_mask.at(i)) {
                     // applying b jet energy correction
-                    corr_pt = jet_pt.at(i) * scale_factor.at(i);
-
+                    corr_pt = pts.at(i) * scale_factors.at(i);
                     Logger::get("physicsobject::jet::PtCorrectionBJets")
                         ->debug("applying b jet energy correction: orig. jet "
                                 "pt {} to corrected "
                                 "jet pt {} with correction factor {}",
-                                jet_pt.at(i), corr_pt, scale_factor.at(i));
+                                pts.at(i), corr_pt, scale_factors.at(i));
                 }
-                pt_values_corrected.push_back(corr_pt);
+                corrected_pts.push_back(corr_pt);
             }
-            return pt_values_corrected;
-            },
-            {jet_pt, scale_factor, bjet_mask});
+            return corrected_pts;
+            };
+
+    auto df1 = df.Define(outputname, bjet_pt_correction,
+                         {jet_pt, scale_factor, bjet_mask});
+    return df1;
 }
 
 /**


### PR DESCRIPTION
This PR introduces a jet pt correction for b-jets. This correction is only present for Run2 datasets, not Run3. Applying this correction can help to get a better b-jet energy estimation which is especially relevant for analyses targeting b-quark in the final state. It should be applied on top of the JECs.

Further, two ratio quantities are introduces for fatjets. Nsubjettiness can help in analyzing jet substructure and the ParticleNet scores can be trasformed to be relative to the QCD background (this quantity is only needed for nanoAODv9 since it is already directly present in higher versions). 