### PR TITLE
Shrink list of valid decay modes to {0, 1, 10, 11}

### DIFF
--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -279,7 +279,7 @@ PtCorrectionMC(
                 // ensure that the tau fulfills the selection criteria for application of the correction,
                 // set the correction factor to 1 otherwise
                 float correction_factor = 1.0;
-                const std::unordered_set<int> valid_modes = {0, 1, 2, 10, 11};
+                const std::unordered_set<int> valid_modes = {0, 1, 10, 11};
                 if (valid_modes.count(decay_mode)) {
                     if ((id_vs_jet_wp == "") && (id_vs_ele_wp == "")) {
                         correction_factor = evaluator->evaluate(


### PR DESCRIPTION
Remove the decay mode 2 from list of allowed decay modes in tau ID SF evaluator, as the preliminary new tau ID SFs cannot handle this decay mode.