### PR TITLE
Extend range of eta values for tau ID vs muon scale factors

### DIFF
--- a/src/taus.cxx
+++ b/src/taus.cxx
@@ -1211,8 +1211,6 @@ Id_vsEle(ROOT::RDF::RNode df,
  * (\f$1.2 \leq |\eta| <1.7\f$), "nom" for nominal and "up"/"down" the up/down variation
  * @param variation_wheel5 name of the scale factor variation for the muon wheel
  * (\f$1.7 \leq |\eta| <2.3\f$), "nom" for nominal and "up"/"down" the up/down variation
- * @param max_abs_eta maximum absolute pseudorapidity of a tau to obtain a meaningful scale factor.
- * Default is 2.3, which is the recommended hadronic tau accepance in Run 2 analyses.
  *
  * @return a new dataframe containing the new column
  */
@@ -1229,8 +1227,7 @@ Id_vsMu(ROOT::RDF::RNode df,
         const std::string &variation_wheel2, 
         const std::string &variation_wheel3,
         const std::string &variation_wheel4, 
-        const std::string &variation_wheel5
-) {
+        const std::string &variation_wheel5) {
     
     const std::map<float, std::string> variations = {
         {0.0f, variation_wheel1},


### PR DESCRIPTION
For the last bin of the tau ID vs muon scale factors, the upper bin edge for eta has been increased from 2.3 to 2.4 to fully cover the acceptance range of taus in Run 3 (|eta| < 2.5). Run 2 analyses should not be affected by this, as the input bins already have a cut on |eta| < 2.3.