### PR TITLE
Switch std::cerr and std::cout to Logger for FastMTT code

### DIFF
--- a/include/RecoilCorrections/RecoilCorrector.hxx
+++ b/include/RecoilCorrections/RecoilCorrector.hxx
@@ -28,7 +28,7 @@ class RecoilCorrector {
         if (bins.size() < 2) {
             return 0;
         }
-        for (size_t iB = 0; iB < bins.size(); ++iB) {
+        for (size_t iB = 0; iB < (bins.size() - 1); ++iB) {
             if (x >= bins[iB] && x < bins[iB + 1])
                 return iB;
         }
@@ -42,7 +42,7 @@ class RecoilCorrector {
         if (nbins < 1) {
             return 0;
         }
-        for (int iB = 0; iB < nbins; ++iB) {
+        for (int iB = 0; iB < (nbins - 1); ++iB) {
             if (x >= bins[iB] && x < bins[iB + 1]) {
                 return iB;
             }

--- a/src/SVFit/FastMTT.cxx
+++ b/src/SVFit/FastMTT.cxx
@@ -335,10 +335,9 @@ FastMTT::run(const std::vector<fastmtt::MeasuredTauLepton> &measuredTauLeptons,
     FastMTT::initialize();
     bestP4 = LorentzVector();
     if (measuredTauLeptons.size() != 2) {
-        Logger::get("FastMTT")->debug(
-            "Number of MeasuredTauLepton is {} a user should pass exactly two leptons.", 
-            measuredTauLeptons.size()
-        );
+        Logger::get("FastMTT")->debug("Number of MeasuredTauLepton is {} a "
+                                      "user should pass exactly two leptons.",
+                                      measuredTauLeptons.size());
         return ROOT::Math::PtEtaPhiMVector();
     }
     std::vector<fastmtt::MeasuredTauLepton> sortedMeasuredTauLeptons =

--- a/src/SVFit/FastMTT.cxx
+++ b/src/SVFit/FastMTT.cxx
@@ -258,8 +258,9 @@ double Likelihood::metTF(const LorentzVector &metP4, const LorentzVector &nuP4,
     double covDet = invCovMETxx * invCovMETyy - invCovMETxy * invCovMETyx;
 
     if (std::abs(covDet) < 1E-10) {
-        std::cerr << "Error: Cannot invert MET covariance Matrix (det=0) !!"
-                  << "METx: " << aMETy << " METy: " << aMETy << std::endl;
+        Logger::get("FastMTT")->debug(
+            "Cannot invert MET covariance Matrix (det=0) !! METx: {} METy: {}",
+            aMETx, aMETy);
         return 0;
     }
     double const_MET = 1. / (2. * M_PI * TMath::Sqrt(covDet));
@@ -334,9 +335,10 @@ FastMTT::run(const std::vector<fastmtt::MeasuredTauLepton> &measuredTauLeptons,
     FastMTT::initialize();
     bestP4 = LorentzVector();
     if (measuredTauLeptons.size() != 2) {
-        std::cout << "Number of MeasuredTauLepton is "
-                  << measuredTauLeptons.size()
-                  << " a user shouls pass exactly two leptons." << std::endl;
+        Logger::get("FastMTT")->debug(
+            "Number of MeasuredTauLepton is {} a user should pass exactly two leptons.", 
+            measuredTauLeptons.size()
+        );
         return ROOT::Math::PtEtaPhiMVector();
     }
     std::vector<fastmtt::MeasuredTauLepton> sortedMeasuredTauLeptons =


### PR DESCRIPTION
The `std::cerr` can causing problems with the buffer when running in a job, therefore, the prints are now moved to the Logger and can be printed it running in debug mode.

Additionally, a small bin loop issues is fixed.