### PR TITLE
Rename of cut producers

### DIFF
--- a/analysis_configurations/template_analysis/producers/muons.py
+++ b/analysis_configurations/template_analysis/producers/muons.py
@@ -14,15 +14,15 @@ with defaults(scopes=["global"]):
             input=[nanoAOD.Muon_pt],
         )
         MuonEtaCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {muon_max_eta})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {muon_max_eta})",
             input=[nanoAOD.Muon_eta],
         )
         MuonDxyCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {muon_max_dxy})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {muon_max_dxy})",
             input=[nanoAOD.Muon_dxy],
         )
         MuonDzCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {muon_max_dz})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {muon_max_dz})",
             input=[nanoAOD.Muon_dz],
         )
         MuonIDCut = Producer(
@@ -30,7 +30,7 @@ with defaults(scopes=["global"]):
             input=[nanoAOD.Muon_mediumId],
         )
         MuonIsoCut = Producer(
-            call="physicsobject::CutMax<float>({df}, {output}, {input}, {muon_max_iso})",
+            call="physicsobject::CutSmaller<float>({df}, {output}, {input}, {muon_max_iso})",
             input=[nanoAOD.Muon_pfRelIso04_all],
         )
     BaseMuons = ProducerGroup(
@@ -58,11 +58,11 @@ with defaults(scopes=["mm"]):
             input=[nanoAOD.Muon_pt],
         )
         GoodMuonEtaCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {muon_max_eta})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {muon_max_eta})",
             input=[nanoAOD.Muon_eta],
         )
         GoodMuonIsoCut = Producer(
-            call="physicsobject::CutMax<float>({df}, {output}, {input}, {muon_max_iso})",
+            call="physicsobject::CutSmaller<float>({df}, {output}, {input}, {muon_max_iso})",
             input=[nanoAOD.Muon_pfRelIso04_all],
         )
     GoodMuons = ProducerGroup(

--- a/analysis_configurations/template_analysis/producers/scalefactors.py
+++ b/analysis_configurations/template_analysis/producers/scalefactors.py
@@ -59,7 +59,7 @@ with defaults(scopes=["mm"], input=[q.pt_2, q.eta_2]):
         output=[q.reco_wgt_mu_2],
     )
     Muon_2_ID_SF = Producer(
-        call="""physicsobject::muon::scalefactor::IsoAndID(
+        call="""physicsobject::muon::scalefactor::IosAndID(
             {df},
             correctionManager,
             {output},

--- a/analysis_configurations/unittest/producers/electrons.py
+++ b/analysis_configurations/unittest/producers/electrons.py
@@ -14,15 +14,15 @@ with defaults(scopes=["global"]):
             input=[nanoAOD.Electron_pt],
         )
         ElectronEtaCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_ele_eta})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_ele_eta})",
             input=[nanoAOD.Electron_eta],
         )
         ElectronDxyCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_ele_dxy})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_ele_dxy})",
             input=[nanoAOD.Electron_dxy],
         )
         ElectronDzCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_ele_dz})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_ele_dz})",
             input=[nanoAOD.Electron_dz],
         )
         ElectronIDCut = Producer(
@@ -30,7 +30,7 @@ with defaults(scopes=["global"]):
             input=[nanoAOD.Electron_mvaFall17V2noIso_WP90],
         )
         ElectronIsoCut = Producer(
-            call="physicsobject::CutMax<float>({df}, {output}, {input}, {max_ele_iso})",
+            call="physicsobject::CutSmaller<float>({df}, {output}, {input}, {max_ele_iso})",
             input=[nanoAOD.Electron_pfRelIso03_all],
         )
     BaseElectrons = ProducerGroup(
@@ -58,11 +58,11 @@ with defaults(scopes=["em", "et", "ee"]):
             input=[nanoAOD.Electron_pt],
         )
         GoodElectronEtaCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_electron_eta})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_electron_eta})",
             input=[nanoAOD.Electron_eta],
         )
         GoodElectronIsoCut = Producer(
-            call="physicsobject::CutMax<float>({df}, {output}, {input}, {electron_iso_cut})",
+            call="physicsobject::CutSmaller<float>({df}, {output}, {input}, {electron_iso_cut})",
             input=[nanoAOD.Electron_pfRelIso03_all],
         )
     GoodElectrons = ProducerGroup(

--- a/analysis_configurations/unittest/producers/jets.py
+++ b/analysis_configurations/unittest/producers/jets.py
@@ -85,11 +85,11 @@ with defaults(scopes=["global"]):
             input=[q.Jet_pt_corrected],
         )
         JetEtaCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_jet_eta})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_jet_eta})",
             input=[nanoAOD.Jet_eta],
         )
         BJetEtaCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_bjet_eta})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_bjet_eta})",
             input=[nanoAOD.Jet_eta],
         )
         BTagCut = Producer(

--- a/analysis_configurations/unittest/producers/muons.py
+++ b/analysis_configurations/unittest/producers/muons.py
@@ -14,15 +14,15 @@ with defaults(scopes=["global"]):
             input=[nanoAOD.Muon_pt],
         )
         MuonEtaCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_eta})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_eta})",
             input=[nanoAOD.Muon_eta],
         )
         MuonDxyCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_dxy})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_dxy})",
             input=[nanoAOD.Muon_dxy],
         )
         MuonDzCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_dz})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_dz})",
             input=[nanoAOD.Muon_dz],
         )
         MuonIDCut = Producer(
@@ -30,7 +30,7 @@ with defaults(scopes=["global"]):
             input=[nanoAOD.Muon_mediumId],
         )
         MuonIsoCut = Producer(
-            call="physicsobject::CutMax<float>({df}, {output}, {input}, {muon_iso_cut})",
+            call="physicsobject::CutSmaller<float>({df}, {output}, {input}, {muon_iso_cut})",
             input=[nanoAOD.Muon_pfRelIso04_all],
         )
     BaseMuons = ProducerGroup(
@@ -58,11 +58,11 @@ with defaults(scopes=["em", "mt", "mm"]):
             input=[nanoAOD.Muon_pt],
         )
         GoodMuonEtaCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_eta})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_eta})",
             input=[nanoAOD.Muon_eta],
         )
         GoodMuonIsoCut = Producer(
-            call="physicsobject::CutMax<float>({df}, {output}, {input}, {muon_iso_cut})",
+            call="physicsobject::CutSmaller<float>({df}, {output}, {input}, {muon_iso_cut})",
             input=[nanoAOD.Muon_pfRelIso04_all],
         )
     GoodMuons = ProducerGroup(

--- a/analysis_configurations/unittest/producers/taus.py
+++ b/analysis_configurations/unittest/producers/taus.py
@@ -9,11 +9,11 @@ with defaults(scopes=["global"], output=[]):
         input=[q.Tau_pt_corrected],
     )
     TauEtaCut = Producer(
-        call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_tau_eta})",
+        call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_tau_eta})",
         input=[nanoAOD.Tau_eta],
     )
     TauDzCut = Producer(
-        call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_tau_dz})",
+        call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_tau_dz})",
         input=[nanoAOD.Tau_dz],
     )
     TauDMCut = Producer(
@@ -170,11 +170,11 @@ with defaults(scopes=["et", "mt", "tt"]):
             input=[q.Tau_pt_corrected],
         )
         GoodTauEtaCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_tau_eta})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_tau_eta})",
             input=[nanoAOD.Tau_eta],
         )
         GoodTauDzCut = Producer(
-            call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_tau_dz})",
+            call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_tau_dz})",
             input=[nanoAOD.Tau_dz],
         )
         GoodTauDMCut = Producer(

--- a/include/event.hxx
+++ b/include/event.hxx
@@ -401,9 +401,9 @@ InListFlag(ROOT::RDF::RNode df, const std::string &outputname,
            const std::string &quantity, const std::vector<T> &selection) {
     return df.Define(outputname,
                      [selection](const T &value) {
-                         bool flag = std::find(selection.begin(),
-                                               selection.end(),
-                                               value) != selection.end();
+                         bool flag =
+                             std::find(selection.begin(), selection.end(),
+                                       value) != selection.end();
                          return flag;
                      },
                      {quantity});
@@ -449,10 +449,9 @@ inline ROOT::RDF::RNode Rename(ROOT::RDF::RNode df,
  * @return a dataframe with the new column of type `double`
  */
 template <typename T1, typename T2>
-inline ROOT::RDF::RNode Product(ROOT::RDF::RNode df,
-                                const std::string &outputname,
-                                const std::string &quantity_1,
-                                const std::string &quantity_2) {
+inline ROOT::RDF::RNode
+Product(ROOT::RDF::RNode df, const std::string &outputname,
+        const std::string &quantity_1, const std::string &quantity_2) {
     return df.Define(outputname,
                      [](const T1 &value_1, const T2 &value_2) {
                          double product = static_cast<double>(value_1) *

--- a/include/event.hxx
+++ b/include/event.hxx
@@ -89,17 +89,19 @@ inline ROOT::RDF::RNode EvenOddFlag(ROOT::RDF::RNode df,
 }
 
 /**
- * @brief This function defines a flag for event quantities that satisfy a
- * minimum threshold requirement. The flag is created by comparing the value
- * in the specified quantity column with the given threshold, marking elements
- * as `true` if they pass the cut and `false` otherwise.
+ * @brief This function defines a flag for event quantities that satisfy an
+ * inclusive minimum threshold requirement, i.e. `value >= threshold`. The flag
+ * is created by comparing the value in the specified quantity column with the
+ * given threshold, marking elements as `true` if they pass the cut and `false`
+ * otherwise. The threshold value itself passes the cut here, in contrast to
+ * `GreaterFlag`, which implements the exclusive `value > threshold`.
  *
  * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
  * @param df input dataframe
  * @param outputname name of the new column containing the selected event flag
  * @param quantity name of the quantity column for which the cut should be
  * evaluated, expected to be of type `T`
- * @param threshold minimum threshold value of type `T`
+ * @param threshold inclusive minimum threshold value of type `T`
  *
  * @return a dataframe containing the new flag as a column
  */
@@ -116,44 +118,19 @@ MinFlag(ROOT::RDF::RNode df, const std::string &outputname,
 }
 
 /**
- * @brief This function defines a flag for event quantities that satisfy a
- * minimum threshold requirement. The flag is created by comparing the absolute
- * value in the specified quantity column with the given threshold, marking
- * elements as `true` if they pass the cut and `false` otherwise.
+ * @brief This function defines a flag for event quantities that satisfy an
+ * inclusive maximum threshold requirement, i.e. `value <= threshold`. The flag
+ * is created by comparing the value in the specified quantity column with the
+ * given threshold, marking elements as `true` if they pass the cut and `false`
+ * otherwise. The threshold value itself passes the cut here, in contrast to
+ * `SmallerFlag`, which implements the exclusive `value < threshold`.
  *
  * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
  * @param df input dataframe
  * @param outputname name of the new column containing the selected event flag
  * @param quantity name of the quantity column for which the cut should be
  * evaluated, expected to be of type `T`
- * @param threshold minimum threshold value of type `T`
- *
- * @return a dataframe containing the new flag as a column
- */
-template <typename T>
-inline ROOT::RDF::RNode
-AbsMinFlag(ROOT::RDF::RNode df, const std::string &outputname,
-           const std::string &quantity, const T &threshold) {
-    return df.Define(outputname,
-                     [threshold](const T &value) {
-                         bool flag = abs(value) >= threshold;
-                         return flag;
-                     },
-                     {quantity});
-}
-
-/**
- * @brief This function defines a flag for event quantities that satisfy a
- * maximum threshold requirement. The flag is created by comparing the value
- * in the specified quantity column with the given threshold, marking elements
- * as `true` if they pass the cut and `false` otherwise.
- *
- * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
- * @param df input dataframe
- * @param outputname name of the new column containing the selected event flag
- * @param quantity name of the quantity column for which the cut should be
- * evaluated, expected to be of type `T`
- * @param threshold maximum threshold value of type `T`
+ * @param threshold inclusive maximum threshold value of type `T`
  *
  * @return a dataframe containing the new flag as a column
  */
@@ -163,7 +140,7 @@ MaxFlag(ROOT::RDF::RNode df, const std::string &outputname,
         const std::string &quantity, const T &threshold) {
     return df.Define(outputname,
                      [threshold](const T &value) {
-                         bool flag = value < threshold;
+                         bool flag = value <= threshold;
                          return flag;
                      },
                      {quantity});
@@ -171,23 +148,83 @@ MaxFlag(ROOT::RDF::RNode df, const std::string &outputname,
 
 /**
  * @brief This function defines a flag for event quantities that satisfy a
- * maximum threshold requirement. The flag is created by comparing the absolute
- * value in the specified quantity column with the given threshold, marking
- * elements as `true` if they pass the cut and `false` otherwise.
+ * strict minimum threshold requirement, i.e. `value > threshold`. The flag is
+ * created by comparing the value in the specified quantity column with the
+ * given threshold, marking elements as `true` if they pass the cut and `false`
+ * otherwise. The threshold value itself does not pass the cut here, in
+ * contrast to `MinFlag`, which implements the inclusive `value >= threshold`.
  *
  * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
  * @param df input dataframe
  * @param outputname name of the new column containing the selected event flag
  * @param quantity name of the quantity column for which the cut should be
  * evaluated, expected to be of type `T`
- * @param threshold maximum threshold value of type `T`
+ * @param threshold exclusive minimum threshold value of type `T`
  *
  * @return a dataframe containing the new flag as a column
  */
 template <typename T>
 inline ROOT::RDF::RNode
-AbsMaxFlag(ROOT::RDF::RNode df, const std::string &outputname,
-           const std::string &quantity, const T &threshold) {
+GreaterFlag(ROOT::RDF::RNode df, const std::string &outputname,
+            const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const T &value) {
+                         bool flag = value > threshold;
+                         return flag;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a flag for event quantities that satisfy a
+ * strict maximum threshold requirement, i.e. `value < threshold`. The flag is
+ * created by comparing the value in the specified quantity column with the
+ * given threshold, marking elements as `true` if they pass the cut and `false`
+ * otherwise. The threshold value itself does not pass the cut here, in
+ * contrast to `MaxFlag`, which implements the inclusive `value <= threshold`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected event flag
+ * @param quantity name of the quantity column for which the cut should be
+ * evaluated, expected to be of type `T`
+ * @param threshold exclusive maximum threshold value of type `T`
+ *
+ * @return a dataframe containing the new flag as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+SmallerFlag(ROOT::RDF::RNode df, const std::string &outputname,
+            const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const T &value) {
+                         bool flag = value < threshold;
+                         return flag;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a flag for event quantities whose absolute
+ * value satisfies a strict maximum threshold requirement, i.e.
+ * `abs(value) < threshold`. The flag is created by comparing the absolute
+ * value in the specified quantity column with the given threshold, marking
+ * elements as `true` if they pass the cut and `false` otherwise. This is the
+ * absolute-value counterpart of `SmallerFlag`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected event flag
+ * @param quantity name of the quantity column for which the cut should be
+ * evaluated, expected to be of type `T`
+ * @param threshold exclusive maximum threshold value of type `T`
+ *
+ * @return a dataframe containing the new flag as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+AbsSmallerFlag(ROOT::RDF::RNode df, const std::string &outputname,
+               const std::string &quantity, const T &threshold) {
     return df.Define(outputname,
                      [threshold](const T &value) {
                          bool flag = abs(value) < threshold;
@@ -224,27 +261,33 @@ EqualFlag(ROOT::RDF::RNode df, const std::string &outputname,
 }
 
 /**
- * @brief This function defines a flag for event quantities that satisfy an
- * exact threshold requirement. The flag is created by comparing the absolute
- * value in the specified quantity column with the given threshold, marking
- * elements as `true` if they pass the cut and `false` otherwise.
+ * @brief This function defines a flag for event quantities whose value is
+ * contained in a given list of accepted values. The flag is created by
+ * comparing the value in the specified quantity column against every entry of
+ * the `selection` list, marking elements as `true` if the value is found and
+ * `false` otherwise. This is the event level counterpart of
+ * `physicsobject::CutQuantity`, and it is equivalent to combining one
+ * `EqualFlag` per accepted value with `event::CombineFlags(..., "any_of")`.
  *
- * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @tparam T type of the input quantity and the accepted values (e.g. `int`,
+ * `UChar_t`)
  * @param df input dataframe
  * @param outputname name of the new column containing the selected event flag
  * @param quantity name of the quantity column for which the cut should be
  * evaluated, expected to be of type `T`
- * @param threshold exact threshold value of type `T`
+ * @param selection a vector containing the accepted values of type `T`
  *
  * @return a dataframe containing the new flag as a column
  */
 template <typename T>
 inline ROOT::RDF::RNode
-AbsEqualFlag(ROOT::RDF::RNode df, const std::string &outputname,
-             const std::string &quantity, const T &threshold) {
+InListFlag(ROOT::RDF::RNode df, const std::string &outputname,
+           const std::string &quantity, const std::vector<T> &selection) {
     return df.Define(outputname,
-                     [threshold](const T &value) {
-                         bool flag = abs(value) == threshold;
+                     [selection](const T &value) {
+                         bool flag = std::find(selection.begin(),
+                                               selection.end(),
+                                               value) != selection.end();
                          return flag;
                      },
                      {quantity});
@@ -267,6 +310,40 @@ inline ROOT::RDF::RNode Rename(ROOT::RDF::RNode df,
                                const std::string &outputname,
                                const std::string &quantity) {
     return df.Define(outputname, [](const T &q) { return q; }, {quantity});
+}
+
+/**
+ * @brief This function creates a new column in the dataframe that contains the
+ * product of the values of two existing columns. The two input columns can
+ * have different stored types (e.g. the charges of the two legs of a pair,
+ * which can be stored as `int` and `Short_t`), therefore both types are
+ * template parameters and the values are converted to `double` before the
+ * multiplication. The resulting column is of type `double`, so any subsequent
+ * flag helper has to be instantiated with `double` as well.
+ *
+ * @tparam T1 type of the first input quantity (e.g. `int`, `Short_t`)
+ * @tparam T2 type of the second input quantity (e.g. `int`, `Short_t`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the product
+ * @param quantity_1 name of the first quantity column, expected to be of type
+ * `T1`
+ * @param quantity_2 name of the second quantity column, expected to be of type
+ * `T2`
+ *
+ * @return a dataframe with the new column of type `double`
+ */
+template <typename T1, typename T2>
+inline ROOT::RDF::RNode Product(ROOT::RDF::RNode df,
+                                const std::string &outputname,
+                                const std::string &quantity_1,
+                                const std::string &quantity_2) {
+    return df.Define(outputname,
+                     [](const T1 &value_1, const T2 &value_2) {
+                         double product = static_cast<double>(value_1) *
+                                          static_cast<double>(value_2);
+                         return product;
+                     },
+                     {quantity_1, quantity_2});
 }
 
 /**

--- a/include/event.hxx
+++ b/include/event.hxx
@@ -206,6 +206,93 @@ SmallerFlag(ROOT::RDF::RNode df, const std::string &outputname,
 
 /**
  * @brief This function defines a flag for event quantities whose absolute
+ * value satisfies an inclusive minimum threshold requirement, i.e.
+ * `abs(value) >= threshold`. The flag is created by comparing the absolute
+ * value in the specified quantity column with the given threshold, marking
+ * elements as `true` if they pass the cut and `false` otherwise. This is the
+ * absolute-value counterpart of `MinFlag`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected event flag
+ * @param quantity name of the quantity column for which the cut should be
+ * evaluated, expected to be of type `T`
+ * @param threshold inclusive minimum threshold value of type `T`
+ *
+ * @return a dataframe containing the new flag as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+AbsMinFlag(ROOT::RDF::RNode df, const std::string &outputname,
+           const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const T &value) {
+                         bool flag = abs(value) >= threshold;
+                         return flag;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a flag for event quantities whose absolute
+ * value satisfies an inclusive maximum threshold requirement, i.e.
+ * `abs(value) <= threshold`. The flag is created by comparing the absolute
+ * value in the specified quantity column with the given threshold, marking
+ * elements as `true` if they pass the cut and `false` otherwise. This is the
+ * absolute-value counterpart of `MaxFlag`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected event flag
+ * @param quantity name of the quantity column for which the cut should be
+ * evaluated, expected to be of type `T`
+ * @param threshold inclusive maximum threshold value of type `T`
+ *
+ * @return a dataframe containing the new flag as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+AbsMaxFlag(ROOT::RDF::RNode df, const std::string &outputname,
+           const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const T &value) {
+                         bool flag = abs(value) <= threshold;
+                         return flag;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a flag for event quantities whose absolute
+ * value satisfies a strict minimum threshold requirement, i.e.
+ * `abs(value) > threshold`. The flag is created by comparing the absolute
+ * value in the specified quantity column with the given threshold, marking
+ * elements as `true` if they pass the cut and `false` otherwise. This is the
+ * absolute-value counterpart of `GreaterFlag`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected event flag
+ * @param quantity name of the quantity column for which the cut should be
+ * evaluated, expected to be of type `T`
+ * @param threshold exclusive minimum threshold value of type `T`
+ *
+ * @return a dataframe containing the new flag as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+AbsGreaterFlag(ROOT::RDF::RNode df, const std::string &outputname,
+               const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const T &value) {
+                         bool flag = abs(value) > threshold;
+                         return flag;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a flag for event quantities whose absolute
  * value satisfies a strict maximum threshold requirement, i.e.
  * `abs(value) < threshold`. The flag is created by comparing the absolute
  * value in the specified quantity column with the given threshold, marking
@@ -255,6 +342,35 @@ EqualFlag(ROOT::RDF::RNode df, const std::string &outputname,
     return df.Define(outputname,
                      [threshold](const T &value) {
                          bool flag = value == threshold;
+                         return flag;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a flag for event quantities whose absolute
+ * value satisfies an exact threshold requirement, i.e.
+ * `abs(value) == threshold`. The flag is created by comparing the absolute
+ * value in the specified quantity column with the given threshold, marking
+ * elements as `true` if they pass the cut and `false` otherwise. This is the
+ * absolute-value counterpart of `EqualFlag`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected event flag
+ * @param quantity name of the quantity column for which the cut should be
+ * evaluated, expected to be of type `T`
+ * @param threshold exact threshold value of type `T`
+ *
+ * @return a dataframe containing the new flag as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+AbsEqualFlag(ROOT::RDF::RNode df, const std::string &outputname,
+             const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const T &value) {
+                         bool flag = abs(value) == threshold;
                          return flag;
                      },
                      {quantity});

--- a/include/physicsobjects.hxx
+++ b/include/physicsobjects.hxx
@@ -225,6 +225,64 @@ CutAbsMin(ROOT::RDF::RNode df, const std::string &outputname,
 
 /**
  * @brief This function defines a mask for objects whose absolute value
+ * satisfies an inclusive maximum threshold requirement, i.e.
+ * `abs(value) <= threshold`. The mask is created by comparing the absolute
+ * values in the specified column with the given threshold, marking elements as
+ * `1` if they pass the cut and `0` otherwise. This is the absolute-value
+ * counterpart of `CutMax`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected object mask
+ * @param quantity name of the object column in the NanoAOD for which the
+ * cut should be applied, expected to be of type `ROOT::RVec<T>`
+ * @param threshold inclusive maximum threshold value of type `T`
+ *
+ * @return a dataframe containing the new mask as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+CutAbsMax(ROOT::RDF::RNode df, const std::string &outputname,
+          const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const ROOT::RVec<T> &values) {
+                         ROOT::RVec<int> mask = abs(values) <= threshold;
+                         return mask;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a mask for objects whose absolute value
+ * satisfies a strict minimum threshold requirement, i.e.
+ * `abs(value) > threshold`. The mask is created by comparing the absolute
+ * values in the specified column with the given threshold, marking elements as
+ * `1` if they pass the cut and `0` otherwise. This is the absolute-value
+ * counterpart of `CutGreater`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected object mask
+ * @param quantity name of the object column in the NanoAOD for which the
+ * cut should be applied, expected to be of type `ROOT::RVec<T>`
+ * @param threshold exclusive minimum threshold value of type `T`
+ *
+ * @return a dataframe containing the new mask as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+CutAbsGreater(ROOT::RDF::RNode df, const std::string &outputname,
+              const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const ROOT::RVec<T> &values) {
+                         ROOT::RVec<int> mask = abs(values) > threshold;
+                         return mask;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a mask for objects whose absolute value
  * satisfies a strict maximum threshold requirement, i.e.
  * `abs(value) < threshold`. The mask is created by comparing the absolute
  * values in the specified column with the given threshold, marking elements as
@@ -274,6 +332,35 @@ CutEqual(ROOT::RDF::RNode df, const std::string &outputname,
     return df.Define(outputname,
                      [threshold](const ROOT::RVec<T> &values) {
                          ROOT::RVec<int> mask = values == threshold;
+                         return mask;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a mask for objects whose absolute value
+ * satisfies an exact threshold requirement, i.e. `abs(value) == threshold`.
+ * The mask is created by comparing the absolute values in the specified
+ * column with the given threshold, marking elements as `1` if they pass the
+ * cut and `0` otherwise. This is the absolute-value counterpart of
+ * `CutEqual`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected object mask
+ * @param quantity name of the object column in the NanoAOD for which the
+ * cut should be applied, expected to be of type `ROOT::RVec<T>`
+ * @param threshold exact threshold value of type `T`
+ *
+ * @return a dataframe containing the new mask as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+CutAbsEqual(ROOT::RDF::RNode df, const std::string &outputname,
+            const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const ROOT::RVec<T> &values) {
+                         ROOT::RVec<int> mask = abs(values) == threshold;
                          return mask;
                      },
                      {quantity});

--- a/include/physicsobjects.hxx
+++ b/include/physicsobjects.hxx
@@ -76,17 +76,19 @@ inline ROOT::RDF::RNode CombineMasks(ROOT::RDF::RNode df,
 }
 
 /**
- * @brief This function defines a mask for objects that satisfy a minimum
- * threshold requirement. The mask is created by comparing the values in the
- * specified column with the given threshold, marking elements as `1` if they
- * pass the cut and `0` otherwise.
+ * @brief This function defines a mask for objects that satisfy an inclusive
+ * minimum threshold requirement, i.e. `value >= threshold`. The mask is
+ * created by comparing the values in the specified column with the given
+ * threshold, marking elements as `1` if they pass the cut and `0` otherwise.
+ * The threshold value itself passes the cut here, in contrast to `CutGreater`,
+ * which implements the exclusive `value > threshold`.
  *
  * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
  * @param df input dataframe
  * @param outputname name of the new column containing the selected object mask
  * @param quantity name of the object column in the NanoAOD for which the
  * cut should be applied, expected to be of type `ROOT::RVec<T>`
- * @param threshold minimum threshold value of type `T`
+ * @param threshold inclusive minimum threshold value of type `T`
  *
  * @return a dataframe containing the new mask as a column
  */
@@ -103,17 +105,109 @@ CutMin(ROOT::RDF::RNode df, const std::string &outputname,
 }
 
 /**
- * @brief This function defines a mask for objects that satisfy a minimum
- * threshold requirement. The mask is created by comparing the absolute values
- * in the specified column with the given threshold, marking elements as `1` if
- * they pass the cut and `0` otherwise.
+ * @brief This function defines a mask for objects that satisfy an inclusive
+ * maximum threshold requirement, i.e. `value <= threshold`. The mask is
+ * created by comparing the values in the specified column with the given
+ * threshold, marking elements as `1` if they pass the cut and `0` otherwise.
+ * The threshold value itself passes the cut here, in contrast to `CutSmaller`,
+ * which implements the exclusive `value < threshold`.
  *
  * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
  * @param df input dataframe
  * @param outputname name of the new column containing the selected object mask
  * @param quantity name of the object column in the NanoAOD for which the
  * cut should be applied, expected to be of type `ROOT::RVec<T>`
- * @param threshold minimum threshold value of type `T`
+ * @param threshold inclusive maximum threshold value of type `T`
+ *
+ * @return a dataframe containing the new mask as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+CutMax(ROOT::RDF::RNode df, const std::string &outputname,
+       const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const ROOT::RVec<T> &values) {
+                         ROOT::RVec<int> mask = values <= threshold;
+                         return mask;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a mask for objects that satisfy a strict
+ * minimum threshold requirement, i.e. `value > threshold`. The mask is created
+ * by comparing the values in the specified column with the given threshold,
+ * marking elements as `1` if they pass the cut and `0` otherwise. The
+ * threshold value itself does not pass the cut here, in contrast to `CutMin`,
+ * which implements the inclusive `value >= threshold`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected object mask
+ * @param quantity name of the object column in the NanoAOD for which the
+ * cut should be applied, expected to be of type `ROOT::RVec<T>`
+ * @param threshold exclusive minimum threshold value of type `T`
+ *
+ * @return a dataframe containing the new mask as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+CutGreater(ROOT::RDF::RNode df, const std::string &outputname,
+           const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const ROOT::RVec<T> &values) {
+                         ROOT::RVec<int> mask = values > threshold;
+                         return mask;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a mask for objects that satisfy a strict
+ * maximum threshold requirement, i.e. `value < threshold`. The mask is created
+ * by comparing the values in the specified column with the given threshold,
+ * marking elements as `1` if they pass the cut and `0` otherwise. The
+ * threshold value itself does not pass the cut here, in contrast to `CutMax`,
+ * which implements the inclusive `value <= threshold`.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected object mask
+ * @param quantity name of the object column in the NanoAOD for which the
+ * cut should be applied, expected to be of type `ROOT::RVec<T>`
+ * @param threshold exclusive maximum threshold value of type `T`
+ *
+ * @return a dataframe containing the new mask as a column
+ */
+template <typename T>
+inline ROOT::RDF::RNode
+CutSmaller(ROOT::RDF::RNode df, const std::string &outputname,
+           const std::string &quantity, const T &threshold) {
+    return df.Define(outputname,
+                     [threshold](const ROOT::RVec<T> &values) {
+                         ROOT::RVec<int> mask = values < threshold;
+                         return mask;
+                     },
+                     {quantity});
+}
+
+/**
+ * @brief This function defines a mask for objects whose absolute value
+ * satisfies an inclusive minimum threshold requirement, i.e.
+ * `abs(value) >= threshold`. The mask is created by comparing the absolute
+ * values in the specified column with the given threshold, marking elements as
+ * `1` if they pass the cut and `0` otherwise. This is the absolute-value
+ * counterpart of `CutMin`, and it is typically combined with `CutAbsSmaller`
+ * to select an absolute-value band such as an \f$|\eta|\f$ range: taking the
+ * lower edge inclusive and the upper edge exclusive makes adjacent bands tile
+ * the range without gaps or overlaps.
+ *
+ * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
+ * @param df input dataframe
+ * @param outputname name of the new column containing the selected object mask
+ * @param quantity name of the object column in the NanoAOD for which the
+ * cut should be applied, expected to be of type `ROOT::RVec<T>`
+ * @param threshold inclusive minimum threshold value of type `T`
  *
  * @return a dataframe containing the new mask as a column
  */
@@ -130,51 +224,26 @@ CutAbsMin(ROOT::RDF::RNode df, const std::string &outputname,
 }
 
 /**
- * @brief This function defines a mask for objects that satisfy a maximum
- * threshold requirement. The mask is created by comparing the values in the
- * specified column with the given threshold, marking elements as `1` if they
- * pass the cut and `0` otherwise.
+ * @brief This function defines a mask for objects whose absolute value
+ * satisfies a strict maximum threshold requirement, i.e.
+ * `abs(value) < threshold`. The mask is created by comparing the absolute
+ * values in the specified column with the given threshold, marking elements as
+ * `1` if they pass the cut and `0` otherwise. This is the absolute-value
+ * counterpart of `CutSmaller`.
  *
  * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
  * @param df input dataframe
  * @param outputname name of the new column containing the selected object mask
  * @param quantity name of the object column in the NanoAOD for which the
  * cut should be applied, expected to be of type `ROOT::RVec<T>`
- * @param threshold maximum threshold value of type `T`
+ * @param threshold exclusive maximum threshold value of type `T`
  *
  * @return a dataframe containing the new mask as a column
  */
 template <typename T>
 inline ROOT::RDF::RNode
-CutMax(ROOT::RDF::RNode df, const std::string &outputname,
-       const std::string &quantity, const T &threshold) {
-    return df.Define(outputname,
-                     [threshold](const ROOT::RVec<T> &values) {
-                         ROOT::RVec<int> mask = values < threshold;
-                         return mask;
-                     },
-                     {quantity});
-}
-
-/**
- * @brief This function defines a mask for objects that satisfy a maximum
- * threshold requirement. The mask is created by comparing the absolute values
- * in the specified column with the given threshold, marking elements as `1` if
- * they pass the cut and `0` otherwise.
- *
- * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
- * @param df input dataframe
- * @param outputname name of the new column containing the selected object mask
- * @param quantity name of the object column in the NanoAOD for which the
- * cut should be applied, expected to be of type `ROOT::RVec<T>`
- * @param threshold maximum threshold value of type `T`
- *
- * @return a dataframe containing the new mask as a column
- */
-template <typename T>
-inline ROOT::RDF::RNode
-CutAbsMax(ROOT::RDF::RNode df, const std::string &outputname,
-          const std::string &quantity, const T &threshold) {
+CutAbsSmaller(ROOT::RDF::RNode df, const std::string &outputname,
+              const std::string &quantity, const T &threshold) {
     return df.Define(outputname,
                      [threshold](const ROOT::RVec<T> &values) {
                          ROOT::RVec<int> mask = abs(values) < threshold;
@@ -205,33 +274,6 @@ CutEqual(ROOT::RDF::RNode df, const std::string &outputname,
     return df.Define(outputname,
                      [threshold](const ROOT::RVec<T> &values) {
                          ROOT::RVec<int> mask = values == threshold;
-                         return mask;
-                     },
-                     {quantity});
-}
-
-/**
- * @brief This function defines a mask for objects that satisfy an exact
- * threshold requirement. The mask is created by comparing the absolute values
- * in the specified column with the given threshold, marking elements as `1` if
- * they pass the cut and `0` otherwise.
- *
- * @tparam T type of the threshold and input quantity (e.g. `float`, `int`)
- * @param df input dataframe
- * @param outputname name of the new column containing the selected object mask
- * @param quantity name of the object column in the NanoAOD for which the
- * cut should be applied, expected to be of type `ROOT::RVec<T>`
- * @param threshold exact threshold value of type `T`
- *
- * @return a dataframe containing the new mask as a column
- */
-template <typename T>
-inline ROOT::RDF::RNode
-CutAbsEqual(ROOT::RDF::RNode df, const std::string &outputname,
-            const std::string &quantity, const T &threshold) {
-    return df.Define(outputname,
-                     [threshold](const ROOT::RVec<T> &values) {
-                         ROOT::RVec<int> mask = abs(values) == threshold;
                          return mask;
                      },
                      {quantity});


### PR DESCRIPTION
This PR introduces some missing producers and restructures the names to be coherent everywhere. This means some boundaries in the analyses are now changed if the producers are not updated accordingly.

- `Max` means smaller or equal
- `Min` means greater or equal
- `Smaller` is strictly smaller
- `Greater` is strictly greater

Before `Max` meant smaller, while `Min` was greater equal, making them inconsistent. Test and template analyses are updated because of this to have the same logic. 