### PR TITLE
Improvements to producer modifications

### DIFF
--- a/code_generation/configuration.py
+++ b/code_generation/configuration.py
@@ -478,6 +478,7 @@ class Configuration(object):
         if not isinstance(scopes, list):
             scopes = [scopes]
         rule.set_available_sampletypes(self.available_sample_types)
+        rule.set_available_eras(self.available_eras)
         rule.set_scopes(scopes)
         rule.set_global_scope(self.global_scope)
         self.rules.add(rule)
@@ -556,10 +557,14 @@ class Configuration(object):
         """
         for rule in self.rules:
             rule.apply(
-                self.sample, self.producers, self.unpacked_producers, self.outputs
+                self.sample,
+                self.era,
+                self.producers,
+                self.unpacked_producers,
+                self.outputs,
             )
-            # also update the set of available outputs if the affected sample is the current sample
-            if self.sample in rule.samples:
+            # also update the set of available outputs if the affected sample and era are the current ones
+            if self.sample in rule.samples and self.era in rule.eras:
                 for scope in rule.affected_scopes():
                     if isinstance(rule, RemoveProducer):
                         self.available_outputs[scope][
@@ -636,7 +641,8 @@ class Configuration(object):
             Returns:
                 None
         """
-        for key in config:
+        # over a copy of the keys, the empty ones are deleted while iterating
+        for key in list(config):
             if isinstance(config[key], dict):
                 self._remove_empty_configkeys(config[key])
             # special case for extended vector producers, here we can have a list, that contains empty dicts

--- a/code_generation/exceptions.py
+++ b/code_generation/exceptions.py
@@ -91,6 +91,23 @@ class EraConfigurationError(ConfigurationError):
         super().__init__(self.message)
 
 
+class EraRuleConfigurationError(ConfigurationError):
+    """
+    Exception raised when the era used for a Rule provided by the user is not valid.
+    """
+
+    def __init__(
+        self,
+        era: str,
+        rule,
+        available_eras: Union[Set[str], List[str]],
+    ):
+        self.message = "Era {} cannot be used in Rule {} since the era is not defined. Available eras are {}".format(
+            era, rule, available_eras
+        )
+        super().__init__(self.message)
+
+
 class InvalidProducerConfigurationError(ConfigurationError):
     """
     Exception raised when the producer configuration provided by the user is not valid.

--- a/code_generation/friend_trees.py
+++ b/code_generation/friend_trees.py
@@ -182,6 +182,11 @@ class FriendTreeConfiguration(Configuration):
                     error_message += "      The input information has to be a json file or a root file \n"
                     error_message += "      and added to the cmake command via the -DQUANTITIESMAP=... option"
                     raise ConfigurationError(error_message)
+        missing_scopes = set(self.selected_scopes) - set(data.keys())
+        if missing_scopes:
+            errorstring = f"Scopes {missing_scopes} not found in any of the input information files {input_information_list}.\n"
+            errorstring += f"Available scopes are: {list(data.keys())}"
+            raise ConfigurationError(errorstring)
         return data
 
     def _readout_input_root_file(
@@ -296,6 +301,26 @@ class FriendTreeConfiguration(Configuration):
                         self._shift_producer_inputs(producer, shift, shiftname, scope)
                         self.shifts[scope][shiftname] = {}
 
+    def _available_quantities(self, scope: str, shift: str) -> Set[str]:
+        """Names of the quantities the input files provide for a given shift.
+
+        `_readout_input_information` stores every quantity together with the
+        config it originates from, so that a multifriend production can tell
+        them apart. Callers that only care about the name have to strip that
+        off, otherwise every lookup silently misses.
+
+        Args:
+            scope (str): The scope to look up
+            shift (str): The shift to look up, "" for the nominal quantities
+
+        Returns:
+            Set[str]: The quantity names available for that scope and shift
+        """
+        return {
+            entry[0] if isinstance(entry, tuple) else entry
+            for entry in self.input_quantities_mapping[scope][shift]
+        }
+
     def _shift_producer_inputs(
         self,
         producer: Union[Producer, ProducerGroup],
@@ -318,12 +343,10 @@ class FriendTreeConfiguration(Configuration):
             log.debug("Inputs of producer %s: %s", producer, inputs)
             # only shift if necessary
             if shift in self.input_quantities_mapping[scope].keys():
+                shifted_quantities = self._available_quantities(scope, shift)
                 inputs_to_shift = []
                 for input_quantity in inputs:
-                    if (
-                        input_quantity.name
-                        in self.input_quantities_mapping[scope][shift]
-                    ):
+                    if input_quantity.name in shifted_quantities:
                         inputs_to_shift.append(input_quantity)
                 if len(inputs_to_shift) > 0:
                     log.debug("Adding shift %s to producer %s", shift, producer)
@@ -377,8 +400,7 @@ class FriendTreeConfiguration(Configuration):
                     [x.name for x in producer.get_outputs(scope)]
                 )
             # get all available inputs
-            for input_quantity, _ in self.input_quantities_mapping[scope][""]:
-                available_inputs.add(input_quantity)
+            available_inputs |= self._available_quantities(scope, "")
             # now check if all inputs are available
             missing_inputs = required_inputs - available_inputs
             if len(missing_inputs) > 0:
@@ -416,6 +438,7 @@ class FriendTreeConfiguration(Configuration):
         if not isinstance(scopes, list):
             scopes = [scopes]
         rule.set_available_sampletypes(self.available_sample_types)
+        rule.set_available_eras(self.available_eras)
         rule.set_scopes(scopes)
         # TODO Check if this works without a global scope
         if self.global_scope is not None:

--- a/code_generation/producer.py
+++ b/code_generation/producer.py
@@ -1162,6 +1162,7 @@ ERA_NANOAOD_VERSION_DEFAULTS: Dict[str, str] = {
     "2023postBPix": "v12",
     "2024": "v15",
     "2025": "v15",
+    "2026": "v15",
 }
 
 

--- a/code_generation/rules.py
+++ b/code_generation/rules.py
@@ -9,7 +9,7 @@ from code_generation.producer import (
     TProducerStore,
 )
 from code_generation.quantity import QuantitiesStore
-from code_generation.exceptions import SampleRuleConfigurationError
+from code_generation.exceptions import SampleRuleConfigurationError, EraRuleConfigurationError
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +20,8 @@ class ProducerRule:
         producers: TProducerInput,
         samples: Union[str, List[str]] = [],
         exclude_samples: Union[str, List[str]] = [],
+        eras: Union[str, List[str]] = [],
+        exclude_eras: Union[str, List[str]] = [],
         scopes: Union[str, List[str]] = "global",
         invert: bool = False,
         update_output: bool = True,
@@ -28,8 +30,10 @@ class ProducerRule:
 
         Args:
             producers: A list of producers or producer groups to be modified.
-            samples: A list of samples, for which the rule should be applied. Only one of samples and exclude_samples can be defined.
+            samples: A list of samples, for which the rule should be applied. Only one of samples and exclude_samples can be defined. If neither is defined, the rule applies to all samples.
             exclude_samples: A list of samples, for which the rule should not be applied. Only one of samples and exclude_samples can be defined.
+            eras: A list of eras, for which the rule should be applied. Only one of eras and exclude_eras can be defined. If neither is defined, the rule applies to all eras.
+            exclude_eras: A list of eras, for which the rule should not be applied. Only one of eras and exclude_eras can be defined.
             scopes: The scopes, in which the rule should be applied. Defaults to "global".
             invert: If set, the invert of the rule is applied. Defaults to False.
             update_output: If set, the output quantities are updated. Defaults to True.
@@ -51,6 +55,14 @@ class ProducerRule:
             self.samples = [samples]
         else:
             self.samples = samples
+        if isinstance(exclude_eras, str):
+            self.exclude_eras = [exclude_eras]
+        else:
+            self.exclude_eras = exclude_eras
+        if isinstance(eras, str):
+            self.eras = [eras]
+        else:
+            self.eras = eras
 
     def set_available_sampletypes(self, available_samples) -> None:
         # sanitize input
@@ -58,11 +70,6 @@ class ProducerRule:
             self.available_samples = [available_samples]
         else:
             self.available_samples = available_samples
-        # make sure that either samples or exclude_samples are defined
-        if self.exclude_samples == [] and self.samples == []:
-            raise ValueError(
-                f"ProducerRule: Either samples or exclude_samples have to be defined!: (Rule: {self}, Samples: {self.samples}, Excluded Samples: {self.exclude_samples})"
-            )
         if self.exclude_samples != [] and self.samples != []:
             raise ValueError(
                 f"ProducerRule: Both samples and are exclude_samples are defined, pick one!: (Rule: {self}, Samples: {self.samples}, Excluded Samples: {self.exclude_samples})"
@@ -70,9 +77,32 @@ class ProducerRule:
         # make sure that the sampletypes are valid
         self.validate_sampletypes(self.samples)
         self.validate_sampletypes(self.exclude_samples)
+        # if neither samples nor exclude_samples are defined, the rule applies to every available sample
+        if self.exclude_samples == [] and self.samples == []:
+            self.samples = list(self.available_samples)
         # if exclude_samples are defined, we have to contstruct the list of samples them from the list of available samples
-        if self.exclude_samples != []:
+        elif self.exclude_samples != []:
             self.samples = list(set(self.available_samples) - set(self.exclude_samples))
+
+    def set_available_eras(self, available_eras) -> None:
+        # sanitize input
+        if isinstance(available_eras, str):
+            self.available_eras = [available_eras]
+        else:
+            self.available_eras = available_eras
+        if self.exclude_eras != [] and self.eras != []:
+            raise ValueError(
+                f"ProducerRule: Both eras and exclude_eras are defined, pick one!: (Rule: {self}, Eras: {self.eras}, Excluded Eras: {self.exclude_eras})"
+            )
+        # make sure that the eras are valid
+        self.validate_eratypes(self.eras)
+        self.validate_eratypes(self.exclude_eras)
+        # if neither eras nor exclude_eras are defined, the rule applies to every available era
+        if self.exclude_eras == [] and self.eras == []:
+            self.eras = list(self.available_eras)
+        # if exclude_eras are defined, we have to construct the list of eras from the list of available eras
+        elif self.exclude_eras != []:
+            self.eras = list(set(self.available_eras) - set(self.exclude_eras))
 
     def set_scopes(self, scopes: List[str]) -> None:
         if isinstance(scopes, str):
@@ -101,9 +131,22 @@ class ProducerRule:
             if sample not in self.available_samples:
                 raise SampleRuleConfigurationError(sample, self, self.available_samples)
 
-    # Evaluate whether modification should be applied depending on sample and inversion flag
-    def is_applicable(self, sample: str) -> bool:
-        applicable = sample in self.samples
+    def validate_eratypes(self, eratypes: List[str]) -> None:
+        """Function to check, if a rule is applicable, or if one of the defined eras is not available.
+
+        Args:
+            available_eras (List[str]): List of available eras.
+
+        Returns:
+            None
+        """
+        for era in eratypes:
+            if era not in self.available_eras:
+                raise EraRuleConfigurationError(era, self, self.available_eras)
+
+    # Evaluate whether modification should be applied depending on sample, era, and inversion flag
+    def is_applicable(self, sample: str, era: str) -> bool:
+        applicable = sample in self.samples and era in self.eras
         if self.invert:
             applicable = not applicable
         return applicable
@@ -122,13 +165,14 @@ class ProducerRule:
     def apply(
         self,
         sample: str,
+        era: str,
         producers_to_be_updated: TProducerStore,
         unpacked_producers: TProducerStore,
         outputs_to_be_updated: QuantitiesStore,
     ) -> None:
-        if self.is_applicable(sample):
-            log.warning(f"Applying rule {self} for sample {sample}")
-            log.debug("For sample {}, applying >> {} ".format(sample, self))
+        if self.is_applicable(sample, era):
+            log.warning(f"Applying rule {self} for sample {sample}, era {era}")
+            log.debug("For sample {}, era {}, applying >> {} ".format(sample, era, self))
             self.update_producers(producers_to_be_updated, unpacked_producers)
             self.update_outputs(outputs_to_be_updated)
 

--- a/code_generation/rules.py
+++ b/code_generation/rules.py
@@ -9,7 +9,10 @@ from code_generation.producer import (
     TProducerStore,
 )
 from code_generation.quantity import QuantitiesStore
-from code_generation.exceptions import SampleRuleConfigurationError, EraRuleConfigurationError
+from code_generation.exceptions import (
+    SampleRuleConfigurationError,
+    EraRuleConfigurationError,
+)
 
 log = logging.getLogger(__name__)
 
@@ -172,7 +175,9 @@ class ProducerRule:
     ) -> None:
         if self.is_applicable(sample, era):
             log.warning(f"Applying rule {self} for sample {sample}, era {era}")
-            log.debug("For sample {}, era {}, applying >> {} ".format(sample, era, self))
+            log.debug(
+                "For sample {}, era {}, applying >> {} ".format(sample, era, self)
+            )
             self.update_producers(producers_to_be_updated, unpacked_producers)
             self.update_outputs(outputs_to_be_updated)
 


### PR DESCRIPTION
Now the `ReplaceProducer`, `RemoveProducer`, and `AppendProducer` methods take `eras` and `exclude_eras` parameters in the same logic of `samples` and `exclude_samples`, both of which are also now optional, with a default that the method will be applied to all samples and eras if no list is ever specified.