### PR TITLE
Update docs for eos

### DIFF
--- a/docs/sphinx_source/kingmaker.rst
+++ b/docs/sphinx_source/kingmaker.rst
@@ -376,6 +376,18 @@ For example:
     xrootd.stat: DEBUG
 
 
+KingMaker Installation in lxplus
+-----------------------
+
+KingMaker and CROWN can be installed in lxplus, and it is recommended to do so under the user's `/eos` space, since CROWN tarballs can get heavy. 
+Because of that, eos job submission only is supported. The setup and configuration is auto-detected and unchanged from previous instructions.
+
+One thing to note is that to run `condor_q` from a new shell and see the current jobs (on the same or different machine), you need to first source the KingMaker setup, as this will
+resolve the particular scheduler used for submission. Otherwise you can run `condor_q -global` to see all of them at the same time. 
+
+The user's proxy certificate is copied locally to keep it alive across new logins and machines.
+
+
 Local debugging
 -----------------------
 


### PR DESCRIPTION
Update to include information on how to submit jobs from lxplus/eos machines, related to [KingMaker PR #108](https://github.com/KIT-CMS/KingMaker/pull/108).